### PR TITLE
Fix FastscrollBubble reliability and Android 15 edge-to-edge display

### DIFF
--- a/motmbrowser/build.gradle
+++ b/motmbrowser/build.gradle
@@ -18,9 +18,9 @@ plugins {
 
 
 def versionMajor = 2
-def versionMinor = 5
+def versionMinor = 8
 def versionPatch = 0
-def versionBuild = 2501
+def versionBuild = 2801
 
 android {
     compileSdkVersion buildConfig.compileSdk

--- a/motmbrowser/src/main/java/com/bammellab/motm/MainActivity.kt
+++ b/motmbrowser/src/main/java/com/bammellab/motm/MainActivity.kt
@@ -19,6 +19,8 @@ import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.LifecycleObserver
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
@@ -44,6 +46,15 @@ class MainActivity :
         super.onCreate(savedInstanceState)
 
         setContentView(R.layout.activity_main)
+
+        // Handle edge-to-edge display for Android 15+ (SDK 35)
+        val container = findViewById<ConstraintLayout>(R.id.container)
+        ViewCompat.setOnApplyWindowInsetsListener(container) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
         PrefsUtil.managePrefsInBackground()
 
         navView = findViewById(R.id.nav_view)

--- a/motmbrowser/src/main/java/com/bammellab/motm/about/AboutActivity.kt
+++ b/motmbrowser/src/main/java/com/bammellab/motm/about/AboutActivity.kt
@@ -16,6 +16,8 @@ package com.bammellab.motm.about
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.bammellab.motm.MainActivity
 import com.bammellab.motm.R
 
@@ -24,12 +26,17 @@ class AboutActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_about)
+
+        // Handle edge-to-edge display for Android 15+ (SDK 35)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(android.R.id.content)) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
         setSupportActionBar(findViewById(R.id.toolbar))
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
         title = ""
-
-        //findViewById<CollapsingToolbarLayout>(R.id.toolbar_layout).title = title
-
     }
 
     override fun onBackPressed() {

--- a/motmbrowser/src/main/java/com/bammellab/motm/graphics/MotmGraphicsActivity.kt
+++ b/motmbrowser/src/main/java/com/bammellab/motm/graphics/MotmGraphicsActivity.kt
@@ -24,6 +24,9 @@ import android.widget.Button
 import android.widget.PopupMenu
 import android.widget.ProgressBar
 import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.bammellab.mollib.GLSurfaceViewDisplayPdbFile
 import com.bammellab.mollib.LoadFromSource.FROM_RCSB_OR_CACHE
 import com.bammellab.mollib.MollibProcessPdbs
@@ -75,6 +78,15 @@ class MotmGraphicsActivity : AppCompatActivity() {
         // TODO: complain dialog if the list is empty
 
         setContentView(R.layout.activity_graphics)
+
+        // Handle edge-to-edge display for Android 15+ (SDK 35)
+        val container = findViewById<ConstraintLayout>(R.id.activity_graphics_layout)
+        ViewCompat.setOnApplyWindowInsetsListener(container) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            view.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+
         buttonPreviousObj = findViewById(R.id.button_prev_obj)
         buttonNextObj = findViewById(R.id.button_next_obj)
         buttonSelect = findViewById(R.id.button_select)


### PR DESCRIPTION
## Summary

- **Fix FastscrollBubble reliability issues** - Critical bug fixes including correcting `bottomAddedScrollValue` to `topAddedScrollValue`, moving static state to instance variables, adding bounds checking, and proper resource cleanup in ON_DESTROY
- **Fix edge-to-edge display for Android 15 (SDK 35)** - Add `WindowInsetsCompat` listener to handle system bar insets in MainActivity, AboutActivity, and MotmGraphicsActivity so content doesn't draw behind status bar and navigation bar
- **Bump version to 2.8.0**

## Test plan

- [ ] Verify app content displays below status bar on Android 15 devices
- [ ] Verify bottom navigation stays above system navigation bar
- [ ] Test FastscrollBubble scrolling in Browse fragment - should track correctly at top/bottom boundaries
- [ ] Verify no memory leaks from FastscrollBubble on fragment destroy

🤖 Generated with [Claude Code](https://claude.com/claude-code)