### PR TITLE
Fix Android 15 edge-to-edge, accessibility, and RTL issues

### DIFF
--- a/motmbrowser/src/main/res/layout/activity_about.xml
+++ b/motmbrowser/src/main/res/layout/activity_about.xml
@@ -45,7 +45,7 @@
                 android:layout_gravity="bottom"
                 app:layout_collapseMode="parallax"
                 android:src="@drawable/bammellaboneline"
-                tools:ignore="ContentDescription" />
+                android:contentDescription="@string/content_desc_bammellab_logo" />
 
             <androidx.appcompat.widget.Toolbar
                 android:id="@+id/toolbar"

--- a/motmbrowser/src/main/res/layout/activity_graphics.xml
+++ b/motmbrowser/src/main/res/layout/activity_graphics.xml
@@ -12,8 +12,8 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:ignore="MissingConstraints" />
 
@@ -26,7 +26,7 @@
         android:layout_weight="1"
         android:text="@string/button_prev_obj"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintRight_toLeftOf="@+id/button_select"
+        app:layout_constraintEnd_toStartOf="@+id/button_select"
         tools:ignore="ButtonStyle" />
 
     <Button
@@ -39,8 +39,8 @@
         android:text="@string/button_next_obj"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintHorizontal_bias="0.69"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toLeftOf="@+id/button_prev_obj"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/button_prev_obj"
         tools:ignore="ButtonStyle" />
 
     <Button
@@ -52,7 +52,7 @@
         android:layout_weight="1"
         android:text="@string/button_select"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintRight_toLeftOf="@+id/button_change_viewmode"
+        app:layout_constraintEnd_toStartOf="@+id/button_change_viewmode"
         tools:ignore="ButtonStyle" />
 
     <Button
@@ -63,7 +63,7 @@
         android:layout_weight="1"
         android:text="@string/button_change_view"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         tools:ignore="ButtonStyle" />
 
 
@@ -72,12 +72,11 @@
         style="?android:attr/progressBarStyleLarge"
         android:layout_width="76dp"
         android:layout_height="76dp"
-        android:layout_gravity="right|top"
+        android:layout_gravity="end|top"
         android:indeterminate="true"
         android:visibility="invisible"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:ignore="RtlHardcoded"
         tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/motmbrowser/src/main/res/layout/activity_main.xml
+++ b/motmbrowser/src/main/res/layout/activity_main.xml
@@ -28,8 +28,8 @@
         android:layout_marginEnd="0dp"
         android:background="?android:attr/windowBackground"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:menu="@menu/bottom_nav_menu" />
 
     <fragment
@@ -38,8 +38,8 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:defaultNavHost="true"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@+id/nav_view"
         app:navGraph="@navigation/mobile_navigation"

--- a/motmbrowser/src/main/res/layout/fragment_browse.xml
+++ b/motmbrowser/src/main/res/layout/fragment_browse.xml
@@ -52,7 +52,7 @@
                 android:fitsSystemWindows="true"
                 app:layout_collapseMode="parallax"
                 android:src="@drawable/bammellaboneline"
-                tools:ignore="ContentDescription" />
+                android:contentDescription="@string/content_desc_bammellab_logo" />
 
             </com.google.android.material.appbar.CollapsingToolbarLayout>
 

--- a/motmbrowser/src/main/res/layout/fragment_fastscroll.xml
+++ b/motmbrowser/src/main/res/layout/fragment_fastscroll.xml
@@ -40,10 +40,9 @@
         android:focusable="true"
         android:src="@drawable/ic_fastscroll_slider_lightmode"
         android:visibility="visible"
-
+        android:contentDescription="@string/content_desc_fastscroll_thumb"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="parent"
-        tools:ignore="ContentDescription"
         tools:visibility="visible" />
 
     <!--Time Markers-->

--- a/motmbrowser/src/main/res/layout/fragment_search.xml
+++ b/motmbrowser/src/main/res/layout/fragment_search.xml
@@ -24,7 +24,7 @@
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
-        android:elevation="6dp">
+        android:elevation="@dimen/toolbar_elevation">
 
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/search_toolbar"
@@ -32,14 +32,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clipChildren="false"
-            android:paddingLeft="@dimen/list_item_header_padding"
-            android:paddingRight="@dimen/list_item_header_padding"
+            android:paddingStart="@dimen/list_item_header_padding"
+            android:paddingEnd="@dimen/list_item_header_padding"
             app:contentInsetStartWithNavigation="0dp"
             >
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="48dp"
+                android:layout_height="@dimen/toolbar_search_height"
                 android:gravity="center_vertical"
                 android:orientation="horizontal">
 
@@ -50,8 +50,10 @@
                     android:layout_weight="1"
                     android:background="@null"
                     android:hint="@string/search_hint"
+                    android:contentDescription="@string/search_hint"
                     android:imeOptions="flagNoExtractUi|actionSearch"
-                    android:inputType="textNoSuggestions" />
+                    android:inputType="textNoSuggestions"
+                    android:autofillHints="none" />
 
                 <ImageButton
                     android:id="@+id/clear_button_in_fragment_search"

--- a/motmbrowser/src/main/res/layout/fragment_search_item_textview.xml
+++ b/motmbrowser/src/main/res/layout/fragment_search_item_textview.xml
@@ -21,6 +21,6 @@
     android:fontFamily="sans-serif"
     android:gravity="center_vertical"
     android:paddingStart="16dp"
+    android:paddingEnd="16dp"
     android:textSize="20sp"
-    tools:text="Sample recent search term"
-    tools:ignore="RtlSymmetry" />
+    tools:text="Sample recent search term" />

--- a/motmbrowser/src/main/res/layout/fragment_search_list_header.xml
+++ b/motmbrowser/src/main/res/layout/fragment_search_list_header.xml
@@ -17,9 +17,9 @@
     style="@style/MyCardViewStyle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/card_margin"
+    android:layout_marginStart="@dimen/card_margin"
     android:layout_marginTop="@dimen/card_margin_skinny"
-    android:layout_marginRight="@dimen/card_margin"
+    android:layout_marginEnd="@dimen/card_margin"
     android:layout_marginBottom="@dimen/card_margin_skinny"
 
     android:clickable="true"

--- a/motmbrowser/src/main/res/layout/fragment_search_list_header.xml
+++ b/motmbrowser/src/main/res/layout/fragment_search_list_header.xml
@@ -36,8 +36,8 @@
             android:layout_height="50dp"
             android:background="@drawable/ic_arrow_drop_down_grey_24px"
             app:layout_constraintBottom_toBottomOf="parent"
+            android:contentDescription="@string/content_desc_expand_collapse"
             app:layout_constraintEnd_toEndOf="parent"
-            tools:ignore="ContentDescription"
             tools:layout_constraintLeft_creator="1"
             tools:layout_constraintTop_creator="1" />
 

--- a/motmbrowser/src/main/res/layout/fragment_search_list_item.xml
+++ b/motmbrowser/src/main/res/layout/fragment_search_list_item.xml
@@ -17,9 +17,9 @@
     style="@style/MyCardViewStyle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/card_margin"
+    android:layout_marginStart="@dimen/card_margin"
     android:layout_marginTop="@dimen/card_margin_skinny"
-    android:layout_marginRight="@dimen/card_margin"
+    android:layout_marginEnd="@dimen/card_margin"
     android:layout_marginBottom="@dimen/card_margin_skinny"
 
     android:clickable="true"

--- a/motmbrowser/src/main/res/layout/fragment_search_list_item.xml
+++ b/motmbrowser/src/main/res/layout/fragment_search_list_item.xml
@@ -36,7 +36,7 @@
             android:layout_height="100dp"
             android:contentDescription="@string/molecule_in_question"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             tools:layout_constraintLeft_creator="1"
             tools:layout_constraintTop_creator="1" />

--- a/motmbrowser/src/main/res/layout/fragment_search_matches_card.xml
+++ b/motmbrowser/src/main/res/layout/fragment_search_matches_card.xml
@@ -17,9 +17,9 @@
     style="@style/MyCardViewStyle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/card_margin"
+    android:layout_marginStart="@dimen/card_margin"
     android:layout_marginTop="@dimen/card_margin_skinny"
-    android:layout_marginRight="@dimen/card_margin"
+    android:layout_marginEnd="@dimen/card_margin"
     android:layout_marginBottom="@dimen/card_margin_skinny"
 
     android:clickable="true"

--- a/motmbrowser/src/main/res/layout/fragment_search_recent.xml
+++ b/motmbrowser/src/main/res/layout/fragment_search_recent.xml
@@ -35,7 +35,7 @@
             android:id="@+id/search_empty_image"
             android:layout_width="96dp"
             android:layout_height="96dp"
-            android:contentDescription="@null"
+            android:contentDescription="@string/content_desc_empty_search"
             app:srcCompat="@drawable/ic_search_24px" />
 
         <TextView

--- a/motmbrowser/src/main/res/layout/list_item_header.xml
+++ b/motmbrowser/src/main/res/layout/list_item_header.xml
@@ -37,7 +37,7 @@
         android:background="@drawable/nine_patch_decent_blue"
         android:contentDescription="@string/molecule_in_question"
         app:layout_constraintBottom_toBottomOf="@+id/motmheader"
-        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
@@ -48,8 +48,8 @@
         android:layout_marginTop="8dp"
         android:contentDescription="@string/molecule_in_question"
         android:textColor="@android:color/black"
-        app:layout_constraintLeft_toLeftOf="@+id/blue_ninepatch"
-        app:layout_constraintRight_toRightOf="@+id/blue_ninepatch"
+        app:layout_constraintStart_toStartOf="@+id/blue_ninepatch"
+        app:layout_constraintEnd_toEndOf="@+id/blue_ninepatch"
         app:layout_constraintTop_toTopOf="@+id/blue_ninepatch"
         tools:text="desc goes here" />
 

--- a/motmbrowser/src/main/res/layout/list_item_motm.xml
+++ b/motmbrowser/src/main/res/layout/list_item_motm.xml
@@ -32,7 +32,7 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
         android:contentDescription="@string/molecule_in_question"
-        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:layout_constraintLeft_creator="1"
         tools:layout_constraintTop_creator="1" />
@@ -43,7 +43,7 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:contentDescription="@string/molecule_in_question"
-        app:layout_constraintLeft_toRightOf="@+id/avatar"
+        app:layout_constraintStart_toEndOf="@+id/avatar"
         app:layout_constraintTop_toTopOf="@+id/avatar"
         tools:text="desc goes here" />
 
@@ -54,7 +54,7 @@
         android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
         android:contentDescription="@string/molecule_in_question"
-        app:layout_constraintLeft_toRightOf="@+id/avatar"
+        app:layout_constraintStart_toEndOf="@+id/avatar"
         app:layout_constraintTop_toBottomOf="@+id/motmtext1"
         tools:text="placeholder text" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/motmbrowser/src/main/res/layout/nav_header.xml
+++ b/motmbrowser/src/main/res/layout/nav_header.xml
@@ -28,11 +28,12 @@
 
 
     <ImageView
+        android:id="@+id/nav_header_icon"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="24dp"
+        android:contentDescription="@string/content_desc_app_icon"
         app:srcCompat="@mipmap/ic_launcher"
-        tools:ignore="ContentDescription"
         tools:layout_width="wrap_content" />
 
     <TextView

--- a/motmbrowser/src/main/res/layout/pdb_card.xml
+++ b/motmbrowser/src/main/res/layout/pdb_card.xml
@@ -17,9 +17,9 @@
     style="@style/MyCardViewStyle"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginLeft="@dimen/card_margin"
+    android:layout_marginStart="@dimen/card_margin"
     android:layout_marginTop="@dimen/card_margin_skinny"
-    android:layout_marginRight="@dimen/card_margin"
+    android:layout_marginEnd="@dimen/card_margin"
     android:layout_marginBottom="@dimen/card_margin_skinny"
 
     android:clickable="true"

--- a/motmbrowser/src/main/res/values/colors.xml
+++ b/motmbrowser/src/main/res/values/colors.xml
@@ -20,7 +20,7 @@
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_200">#FF00897B</color>
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>

--- a/motmbrowser/src/main/res/values/dimens.xml
+++ b/motmbrowser/src/main/res/values/dimens.xml
@@ -39,6 +39,10 @@
     <dimen name="text_size">20sp</dimen>
     <dimen name="small_padding">2dp</dimen>
 
+    <!--search toolbar-->
+    <dimen name="toolbar_search_height">48dp</dimen>
+    <dimen name="toolbar_elevation">6dp</dimen>
+
     <!--search items-->
     <dimen name="list_item_vertical_padding">16dp</dimen>
     <dimen name="list_item_horizontal_padding">16dp</dimen>

--- a/motmbrowser/src/main/res/values/strings.xml
+++ b/motmbrowser/src/main/res/values/strings.xml
@@ -136,6 +136,13 @@
         <item>system</item>
     </array>
 
+    <!--Content descriptions for accessibility-->
+    <string name="content_desc_bammellab_logo">Bammellab logo</string>
+    <string name="content_desc_expand_collapse">Expand or collapse section</string>
+    <string name="content_desc_empty_search">No recent searches</string>
+    <string name="content_desc_app_icon">Application icon</string>
+    <string name="content_desc_fastscroll_thumb">Fast scroll handle</string>
+
     <!--About activity strings-->
 
     <string name="about">About</string>

--- a/screensaver/src/main/res/values/colors.xml
+++ b/screensaver/src/main/res/values/colors.xml
@@ -18,7 +18,7 @@
     <color name="purple_200">#FFBB86FC</color>
     <color name="purple_500">#FF6200EE</color>
     <color name="purple_700">#FF3700B3</color>
-    <color name="teal_200">#FF03DAC5</color>
+    <color name="teal_200">#FF00897B</color>
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>


### PR DESCRIPTION
## Summary

- **Fix edge-to-edge display for Android 15 (SDK 35)** - Add WindowInsetsCompat handling to MainActivity, AboutActivity, and MotmGraphicsActivity
- **Fix FastscrollBubble reliability issues** - Bug fixes for scroll state tracking and bounds checking
- **Fix layout XML lint issues** - Multiple accessibility and RTL support improvements:
  - Add contentDescription to ImageViews for screen reader support
  - Replace deprecated paddingLeft/Right with paddingStart/End
  - Replace deprecated marginLeft/Right with marginStart/End
  - Replace deprecated constraintLeft/Right with constraintStart/End
  - Fix text contrast ratio (teal_200 color) for WCAG AA compliance
- **Bump version to 2.8.0**

## Test plan

- [ ] Verify app content displays correctly on Android 15 devices (not behind status/nav bars)
- [ ] Test FastscrollBubble in Browse fragment
- [ ] Verify accessibility with TalkBack screen reader
- [ ] Test RTL layout with device set to RTL language
- [ ] Verify teal accent color has sufficient contrast

🤖 Generated with [Claude Code](https://claude.com/claude-code)