### PR TITLE
Add website verification tests for corpus and category data

### DIFF
--- a/mollib/src/test/java/com/bammellab/mollib/data/CorpusTest.kt
+++ b/mollib/src/test/java/com/bammellab/mollib/data/CorpusTest.kt
@@ -15,6 +15,7 @@
 
 package com.bammellab.mollib.data
 
+import com.bammellab.mollib.data.Corpus.corpus
 import com.bammellab.mollib.data.Corpus.motmDateByKey
 import com.bammellab.mollib.data.Corpus.motmThumbnailImageList
 import org.hamcrest.CoreMatchers.`is`
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.fail
+import java.net.URI
 
 
 /**
@@ -56,11 +58,113 @@ class CorpusTest {
             val num = entry.substringBefore('-')
             try {
                 Integer.parseInt(num)
-            } catch (e: NumberFormatException) {
+            } catch (_: NumberFormatException) {
                 fail("bad value $num for integer at index ${motmThumbnailImageList.size - iter.index}")
             }
             // Each entry should be numbered to match its 1-based position in the list
             assertEquals(num.toInt(), iter.index + 1)
         }
+    }
+
+    /**
+     * Claude Prompt:
+     * The webpage https://pdb101.rcsb.org/motm/motm-by-date lists all the
+     * Molecules Of The Month (motm) categorized by year.  Please create a
+     * test in the mollib that checks the "corpus" table in
+     * mollib/src/main/java/com/bammellab/mollib/data/Corpus.kt against
+     * the website - to verify that the names in the table match the name
+     * given in the website.
+     *
+     * Verifies that the corpus titles match the official RCSB PDB101
+     * "Molecule of the Month" list from the website.
+     *
+     * This test fetches https://pdb101.rcsb.org/motm/motm-by-date and
+     * compares the extracted titles against the local corpus list.
+     */
+    @Test
+    @DisplayName("verify corpus titles match RCSB website")
+    fun verifyCorpusTitlesMatchWebsite() {
+        val url = "https://pdb101.rcsb.org/motm/motm-by-date"
+        val html = try {
+            URI(url).toURL().readText()
+        } catch (e: Exception) {
+            println("Skipping test: Unable to fetch website - ${e.message}")
+            return
+        }
+
+        // Extract all MOTM entries from the HTML
+        // The page contains links like: <a href="/motm/313">Natural RNA-Only Assemblies</a>
+        val motmPattern = Regex("""<a[^>]+href="/motm/(\d+)"[^>]*>([^<]+)</a>""")
+        val websiteEntries = mutableMapOf<Int, String>()
+
+        motmPattern.findAll(html).forEach { match ->
+            val motmNumber = match.groupValues[1].toIntOrNull()
+            val title = match.groupValues[2]
+                .replace("&amp;", "&")
+                .replace("&#39;", "'")
+                .replace("&quot;", "\"")
+                .trim()
+            if (motmNumber != null && title.isNotEmpty()) {
+                // Store the first occurrence (the main link, not navigation duplicates)
+                if (!websiteEntries.containsKey(motmNumber)) {
+                    websiteEntries[motmNumber] = title
+                }
+            }
+        }
+
+        // Verify we got entries from the website
+        if (websiteEntries.isEmpty()) {
+            fail("No MOTM entries found on website - HTML parsing may need updating")
+        }
+
+        val mismatches = mutableListOf<String>()
+        val missing = mutableListOf<Int>()
+
+        // Compare each corpus entry against the website
+        for (index in corpus.indices) {
+            val motmNumber = index + 1 // corpus is 0-indexed, MOTM numbers are 1-indexed
+            val corpusTitle = corpus[index]
+            val websiteTitle = websiteEntries[motmNumber]
+
+            if (websiteTitle == null) {
+                missing.add(motmNumber)
+            } else if (!titlesMatch(corpusTitle, websiteTitle)) {
+                mismatches.add("MOTM $motmNumber: corpus='$corpusTitle' vs website='$websiteTitle'")
+            }
+        }
+
+        // Report results
+        if (missing.isNotEmpty()) {
+            println("MOTM entries not found on website: $missing")
+        }
+
+        if (mismatches.isNotEmpty()) {
+            fail("Title mismatches found:\n${mismatches.joinToString("\n")}")
+        }
+
+        println("Verified ${corpus.size} corpus entries against website (${websiteEntries.size} website entries)")
+    }
+
+    /**
+     * Compares titles with some flexibility for minor formatting differences.
+     * Returns true if titles match or are equivalent variations.
+     */
+    private fun titlesMatch(corpusTitle: String, websiteTitle: String): Boolean {
+        // Exact match
+        if (corpusTitle == websiteTitle) return true
+
+        // Normalize for comparison: lowercase, remove extra whitespace, normalize punctuation
+        val normalizeTitle: (String) -> String = { title ->
+            title.lowercase()
+                .replace(Regex("\\s+"), " ")
+                .replace(Regex("\\s*/\\s*"), "/") // Normalize "a / b" to "a/b"
+                .replace("–", "-")
+                .replace("—", "-")
+                .replace("'", "'")
+                .replace("`", "'")
+                .trim()
+        }
+
+        return normalizeTitle(corpusTitle) == normalizeTitle(websiteTitle)
     }
 }

--- a/mollib/src/test/java/com/bammellab/mollib/data/MotmByCategoryTest.kt
+++ b/mollib/src/test/java/com/bammellab/mollib/data/MotmByCategoryTest.kt
@@ -1,0 +1,157 @@
+/*
+ *  Copyright 2020 Bammellab / James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.bammellab.mollib.data
+
+import com.bammellab.mollib.data.MotmByCategory.MotmCategoryHealth
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import java.net.URI
+
+/**
+ * Tests to verify MotmByCategory data matches the RCSB PDB101 website.
+ */
+class MotmByCategoryTest {
+
+    /**
+     * Verifies that the MotmCategoryHealth table matches the official RCSB PDB101
+     * "Molecule of the Month by Category" page for the Health and Disease section.
+     *
+     * This test fetches https://pdb101.rcsb.org/motm/motm-by-category and verifies:
+     * 1. All category names from local data exist on the website
+     * 2. All MOTM numbers referenced in local data exist on the website
+     */
+    @Test
+    @DisplayName("verify MotmCategoryHealth matches RCSB website")
+    fun verifyMotmCategoryHealthMatchesWebsite() {
+        val url = "https://pdb101.rcsb.org/motm/motm-by-category"
+        val html = try {
+            URI(url).toURL().readText()
+        } catch (e: Exception) {
+            println("Skipping test: Unable to fetch website - ${e.message}")
+            return
+        }
+
+        // Parse the local MotmCategoryHealth array into structured data
+        val localCategories = parseLocalCategoryArray(MotmCategoryHealth)
+
+        // Extract all MOTM numbers from the website
+        val websiteMotmNumbers = extractWebsiteMotmNumbers(html)
+
+        if (websiteMotmNumbers.isEmpty()) {
+            fail("No MOTM numbers found on website - HTML parsing may need updating")
+        }
+
+        // Verify category names exist on website
+        val missingCategories = mutableListOf<String>()
+        for (categoryName in localCategories.keys) {
+            if (!categoryExistsOnWebsite(html, categoryName)) {
+                missingCategories.add(categoryName)
+            }
+        }
+
+        // Verify all MOTM numbers from local data exist on website
+        val allLocalMotmNumbers = localCategories.values.flatten().toSet()
+        val missingMotmNumbers = allLocalMotmNumbers - websiteMotmNumbers
+
+        // Report results
+        val errors = StringBuilder()
+
+        if (missingCategories.isNotEmpty()) {
+            errors.appendLine("Categories in local data but not found on website: $missingCategories")
+        }
+
+        if (missingMotmNumbers.isNotEmpty()) {
+            errors.appendLine("MOTM numbers in local data but not on website: $missingMotmNumbers")
+        }
+
+        if (errors.isNotEmpty()) {
+            fail(errors.toString())
+        }
+
+        println("Verified ${localCategories.size} categories exist on website")
+        println("Verified ${allLocalMotmNumbers.size} unique MOTM numbers from local data exist on website")
+        println("Website has ${websiteMotmNumbers.size} total unique MOTM numbers")
+    }
+
+    /**
+     * Parses the local category array into a map of category name to list of MOTM numbers.
+     */
+    private fun parseLocalCategoryArray(array: Array<String>): Map<String, List<Int>> {
+        val result = mutableMapOf<String, MutableList<Int>>()
+        var currentCategory: String? = null
+
+        for (entry in array) {
+            val trimmed = entry.trim()
+
+            // Skip section header
+            if (trimmed.startsWith("Section ")) {
+                continue
+            }
+
+            // Check if this is a MOTM number (all digits)
+            val motmNumber = trimmed.toIntOrNull()
+            if (motmNumber != null) {
+                // This is a MOTM number - add to current category
+                currentCategory?.let {
+                    result.getOrPut(it) { mutableListOf() }.add(motmNumber)
+                }
+            } else {
+                // This is a category name
+                currentCategory = trimmed
+                result.getOrPut(currentCategory) { mutableListOf() }
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Extracts all MOTM numbers from the website HTML.
+     */
+    private fun extractWebsiteMotmNumbers(html: String): Set<Int> {
+        val motmLinkPattern = Regex("""href="/motm/(\d+)"""")
+        return motmLinkPattern.findAll(html)
+            .mapNotNull { it.groupValues[1].toIntOrNull() }
+            .toSet()
+    }
+
+    /**
+     * Checks if a category name exists on the website (case-insensitive).
+     */
+    private fun categoryExistsOnWebsite(html: String, categoryName: String): Boolean {
+        // Check for exact match or close variations
+        val variations = listOf(
+            categoryName,
+            categoryName.replace("&", "and"),
+            categoryName.replace("and", "&")
+        )
+
+        for (variation in variations) {
+            val escapedName = Regex.escape(variation)
+            // Look for the category name in various HTML contexts
+            val patterns = listOf(
+                Regex(""">$escapedName\s*<""", RegexOption.IGNORE_CASE),
+                Regex(""">$escapedName</""", RegexOption.IGNORE_CASE),
+                Regex(""">\s*$escapedName\s*</a>""", RegexOption.IGNORE_CASE)
+            )
+
+            if (patterns.any { it.containsMatchIn(html) }) {
+                return true
+            }
+        }
+
+        return false
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CorpusTest.verifyCorpusTitlesMatchWebsite` test that fetches the RCSB PDB101 motm-by-date page and verifies all 313 corpus titles match the website
- Add new `MotmByCategoryTest` class with `verifyMotmCategoryHealthMatchesWebsite` test that verifies category names and MOTM numbers from `MotmCategoryHealth` exist on the motm-by-category page
- Both tests gracefully skip if the website is unreachable and include normalization for minor formatting differences

## Test plan
- [x] Run `./gradlew.bat :mollib:test` - all 10 tests pass
- [ ] Verify tests skip gracefully when offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)