### PR TITLE
Upgrade to AGP 9.0 with build fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ stdout
 # Claude - not tracked
 .claude
 
+# Claude - plan files (temps) - not tracked
+
+_claude*
+

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,3 +1,4 @@
+
 # Testing Guide
 
 This document describes the testing infrastructure and test suites for the MotmBrowser project.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.kotlin.ksp) apply false
 }
 
 // Configure test logging for all projects

--- a/captureimages/build.gradle.kts
+++ b/captureimages/build.gradle.kts
@@ -62,7 +62,7 @@ android {
         release {
             isMinifyEnabled = false
             proguardFiles(
-                getDefaultProguardFile("proguard-android.txt"),
+                getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.txt"
             )
             signingConfig = signingConfigs.getByName("release")

--- a/captureimages/build.gradle.kts
+++ b/captureimages/build.gradle.kts
@@ -11,14 +11,12 @@
  *  limitations under the License
  */
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.FileInputStream
 import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
 }
 
 val versionMajor = 2
@@ -72,15 +70,10 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
-    }
     lint {
         abortOnError = false
         checkDependencies = true

--- a/captureimages/build.gradle.kts
+++ b/captureimages/build.gradle.kts
@@ -24,6 +24,12 @@ val versionMinor = 2
 val versionPatch = 0
 val versionBuild = 2201
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
 android {
     namespace = "com.bammellab.captureimages"
     compileSdk = libs.versions.compileSdk.get().toInt()

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,9 +34,22 @@ org.gradle.jvmargs=-Xmx2048m
 kapt.use.worker.api=true
 kapt.incremental.apt=true
 kapt.include.compile.classpath=false
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+
+# AGP 9.0 migration flags
+android.builtInKotlin=false
+android.newDsl=false
+android.defaults.buildfeatures.resvalues=true
+android.experimental.disableCompileTimeRClass=false
+android.suppressUnsupportedCompileSdk=36
+android.disableManifestSdkCheck=true
+android.uniquePackageNames=false
+android.enableDependencyConstraints=true
+android.r8.strictKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.preserveOldDslApis=true
+android.targetSdkDefaultsToCompileSdk=false
 
 # Kotlin JVM target (must match Java sourceCompatibility)
 kotlin.jvm.target=17

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,27 +27,19 @@
 # org.gradle.parallel=true
 # Use R8 instead of ProGuard for code shrinking.
 # android.enableD8=true
-android.enableJetifier=true
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx2048m
-# Allow kapt to use workers, incremental processing
-kapt.use.worker.api=true
-kapt.incremental.apt=true
-kapt.include.compile.classpath=false
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
 
 # AGP 9.0 migration flags
 android.builtInKotlin=false
 android.newDsl=false
-android.defaults.buildfeatures.resvalues=true
 android.experimental.disableCompileTimeRClass=false
 android.suppressUnsupportedCompileSdk=36
 android.disableManifestSdkCheck=true
 android.uniquePackageNames=false
 android.enableDependencyConstraints=true
 android.r8.strictKeepRules=false
-android.r8.optimizedResourceShrinking=false
 android.preserveOldDslApis=true
 android.targetSdkDefaultsToCompileSdk=false
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,7 +86,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 
 # Image loading
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
-glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glide" }
+glide-ksp = { module = "com.github.bumptech.glide:ksp", version.ref = "glide" }
 picasso = { module = "com.squareup.picasso:picasso", version.ref = "picasso" }
 
 # Utilities
@@ -105,4 +105,4 @@ jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "j
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ minSdk = "23"
 targetSdk = "36"
 
 # Plugin versions
-agp = "8.13.2"
+agp = "9.0.0"
 kotlin = "2.3.0"
 
 # Kotlin

--- a/mollib/build.gradle.kts
+++ b/mollib/build.gradle.kts
@@ -16,6 +16,12 @@ plugins {
     alias(libs.plugins.kotlin.android)
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
 android {
     namespace = "com.bammellab.mollib"
     compileSdk = libs.versions.compileSdk.get().toInt()

--- a/mollib/build.gradle.kts
+++ b/mollib/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 /*
  *  Copyright 2022 Bammellab / James Andreas
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -50,14 +48,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 

--- a/motmbrowser/build.gradle.kts
+++ b/motmbrowser/build.gradle.kts
@@ -41,6 +41,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig = true
         dataBinding = true
         viewBinding = true
     }

--- a/motmbrowser/build.gradle.kts
+++ b/motmbrowser/build.gradle.kts
@@ -25,6 +25,12 @@ val versionMinor = 9
 val versionPatch = 3
 val versionBuild = 2903
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
 android {
     namespace = "com.bammellab.motm"
     compileSdk = libs.versions.compileSdk.get().toInt()

--- a/motmbrowser/build.gradle.kts
+++ b/motmbrowser/build.gradle.kts
@@ -11,14 +11,13 @@
  *  limitations under the License
  */
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.FileInputStream
 import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.kotlin.ksp)
 }
 
 val versionMajor = 2
@@ -80,14 +79,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {
@@ -135,7 +128,7 @@ dependencies {
     implementation(libs.timber)
     implementation(libs.picasso)
     implementation(libs.glide)
-    kapt(libs.glide.compiler)
+    ksp(libs.glide.ksp)
 
     testImplementation(libs.jetbrains.annotations)
     testImplementation(libs.junit.jupiter)

--- a/screensaver/build.gradle.kts
+++ b/screensaver/build.gradle.kts
@@ -24,6 +24,12 @@ val versionMinor = 2
 val versionPatch = 0
 val versionBuild = 120
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
 android {
     namespace = "com.bammellab.screensaver"
     compileSdk = libs.versions.compileSdk.get().toInt()

--- a/screensaver/build.gradle.kts
+++ b/screensaver/build.gradle.kts
@@ -11,7 +11,6 @@
  *  limitations under the License
  */
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.FileInputStream
 import java.util.Properties
 
@@ -78,15 +77,10 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
-    }
     lint {
         abortOnError = false
         checkDependencies = true

--- a/screensaver/proguard-rules.pro
+++ b/screensaver/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Screensaver module ProGuard rules

--- a/screensaver/src/main/proguard-motmbrowser.pro
+++ b/screensaver/src/main/proguard-motmbrowser.pro
@@ -1,0 +1,1 @@
+# Screensaver module ProGuard rules

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -62,7 +62,7 @@ android {
         release {
             isMinifyEnabled = false
             proguardFiles(
-                getDefaultProguardFile("proguard-android.txt"),
+                getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.txt"
             )
             signingConfig = signingConfigs.getByName("release")

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -24,6 +24,12 @@ val versionMinor = 2
 val versionPatch = 0
 val versionBuild = 2201
 
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
+}
+
 android {
     namespace = "com.bammellab.standalone"
     compileSdk = libs.versions.compileSdk.get().toInt()

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -11,14 +11,12 @@
  *  limitations under the License
  */
 
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.io.FileInputStream
 import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
 }
 
 val versionMajor = 2
@@ -72,14 +70,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_11
-        }
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     lint {


### PR DESCRIPTION
## Summary
- Upgrade Android Gradle Plugin from 8.13.2 to 9.0.0
- Migrate kapt to KSP, remove deprecated AGP 9.0 properties, unify JVM target to 17
- Set Kotlin JVM target to 17 using the new `compilerOptions` DSL (required for AGP 9.0 compatibility)
- Add release build verification tests and testing documentation
- Various lint fixes and code cleanup

## Test plan
- [x] Full `./gradlew build` passes successfully
- [x] Verify debug APK installs and runs on device/emulator
- [ ] Verify release build with R8 obfuscation

🤖 Generated with [Claude Code](https://claude.com/claude-code)