### PR TITLE
Integrate KotmolPdbParser as local :pdbparser module

### DIFF
--- a/CLAUDE-integrate-pdbparser.md
+++ b/CLAUDE-integrate-pdbparser.md
@@ -1,0 +1,82 @@
+# KotmolPdbParser Integration
+
+## Overview
+
+The PDB parser library (`com.kotmol.kotmolpdbparser:kotmolpdbparser`) has been moved from
+a Maven Central dependency into the repo as a local Gradle module at `pdbparser/`.
+
+This gives full control over the source, enables in-repo debugging, and eliminates the
+external Maven dependency.
+
+## Module Location
+
+```
+pdbparser/
+├── build.gradle.kts                           # Pure Kotlin/JVM module, JUnit 5
+└── src/
+    ├── main/java/com/kotmol/pdbParser/        # 8 core source files
+    │   ├── AtomInformationTable.kt            # Periodic table (118 elements, VdW radii, colors)
+    │   ├── BondInfo.kt                        # ~80KB hardcoded bond database from EBI
+    │   ├── ChainRenderingDescriptor.kt        # Chain rendering metadata (RIBBON, ALPHA_HELIX, etc.)
+    │   ├── Molecule.kt                        # Output container (atoms, bonds, helices, sheets)
+    │   ├── ParserPdbFile.kt                   # Main parser (Builder pattern)
+    │   ├── PdbAtom.kt                         # Atom data + KotmolVector3
+    │   ├── PdbBetaSheet.kt                    # SHEET record data
+    │   └── PdbHelix.kt                        # HELIX record data
+    └── test/java/com/kotmol/pdbParser/        # 23 unit test files
+```
+
+## Usage
+
+The package name `com.kotmol.pdbParser` is unchanged — existing imports in `mollib/` work
+without modification.
+
+```kotlin
+val mol = Molecule()
+ParserPdbFile.Builder(mol)
+    .loadPdbFromStream(pdbByteStream)
+    .parse()
+// Access mol.atomNumberToAtomInfoHash, mol.bondList, mol.helixList, etc.
+```
+
+## Build Commands
+
+```bash
+# Run pdbparser unit tests only
+./gradlew.bat :pdbparser:test
+
+# Build mollib (depends on pdbparser)
+./gradlew.bat :mollib:build
+
+# Full build
+./gradlew.bat build
+```
+
+## Updating the Parser Source
+
+The upstream source is at `C:\a\j\kotlinIdea\KotmolPdbParser`.
+To pull in changes, copy the updated `.kt` files from:
+```
+KotmolPdbParser/kotmolpdbparser/src/main/java/com/kotmol/pdbParser/
+```
+into:
+```
+pdbparser/src/main/java/com/kotmol/pdbParser/
+```
+Then run `:pdbparser:test` to confirm nothing broke.
+
+## Modules That Depend on pdbparser
+
+| Module         | Dependency                  |
+|----------------|-----------------------------|
+| mollib         | `project(":pdbparser")`     |
+| motmbrowser    | `project(":pdbparser")`     |
+| standalone     | `project(":pdbparser")`     |
+| captureimages  | `project(":pdbparser")`     |
+
+## Original Source
+
+The parser was originally published to Maven Central as:
+`com.kotmol.kotmolpdbparser:kotmolpdbparser:1.0.5`
+
+Source repo: `C:\a\j\kotlinIdea\KotmolPdbParser` (local) / GitHub: kotmol/KotmolPdbParser

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,12 +26,23 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Release builds use R8 for code shrinking and obfuscation. R8 scrambles function names (e.g., `calculateUserScore()` becomes `a()`) to reduce file size and protect intellectual property.
 
-**Mapping files** are automatically included in the AAB under `BUNDLE-METADATA/` (AGP 8.13.2+). Google Play uses these to deobfuscate crash reports automatically - no manual upload required.
+**Mapping files** are automatically included in the AAB under `BUNDLE-METADATA/` (AGP 9.0.1). Google Play uses these to deobfuscate crash reports automatically - no manual upload required.
 
 For local debugging, mapping files are generated at:
 - `motmbrowser/build/outputs/mapping/release/mapping.txt`
 
 ProGuard rules are in `motmbrowser/src/main/proguard-motmbrowser.pro`.
+
+## Version Management
+
+Version numbers are in `motmbrowser/build.gradle.kts`:
+```kotlin
+val versionMajor = 2
+val versionMinor = 9
+val versionPatch = 3
+val versionBuild = 2903
+```
+Update these before creating a new release.
 
 ## Testing
 
@@ -57,6 +68,8 @@ ProGuard rules are in `motmbrowser/src/main/proguard-motmbrowser.pro`.
 
 Tests use JUnit 5 (Jupiter) with Truth assertions. Test files are in `mollib/src/test/java/` and `motmbrowser/src/test/java/`.
 
+Some tests in `CorpusTest` and `MotmByCategoryTest` make live network calls to `pdb101.rcsb.org` to verify local data is in sync with the website — they skip gracefully if the network is unavailable.
+
 See [TESTING.md](TESTING.md) for complete testing documentation.
 
 ## Linting
@@ -75,18 +88,19 @@ This is a multi-module Android project written in Kotlin that displays 3D molecu
 
 - **motmbrowser/** - Main Android application
   - MVVM architecture with ViewModels and Fragments
-  - AndroidX Navigation for fragment navigation
+  - AndroidX Navigation for fragment navigation (bottom nav: Browse / Search / Settings)
+  - Molecule detail opens `MotmDetailActivity`; 3D viewer opens `MotmGraphicsActivity`
   - Key packages: `browse/`, `search/`, `detail/`, `graphics/`, `settings/`
 
 - **mollib/** - Core library (shared across all apps)
   - `objects/` - OpenGL ES rendering (RendererDisplayPdbFile, BufferManager, RenderRibbon, etc.)
-  - `data/` - Static molecule data (PDBs.kt, Corpus.kt, MotmByCategory.kt)
+  - `data/` - Static molecule data bundled with the app (PDBs.kt, Corpus.kt, MotmByCategory.kt)
   - `common/math/` - 3D math utilities (Matrix4, Quaternion, MotmVector3)
   - `pdbDownload/` - Network download with OkHttp3
 
 - **standalone/** - Test app for graphics development (loads PDB files from `/storage/emulated/0/PDB/`)
 
-- **captureimages/** - Utility for generating PDB thumbnail images
+- **captureimages/** - Utility for generating PDB thumbnail images (output uploaded to `jimandreas/MotmImages` on GitHub)
 
 - **screensaver/** - Muzei live wallpaper plugin
 
@@ -94,10 +108,17 @@ This is a multi-module Android project written in Kotlin that displays 3D molecu
 
 - OpenGL ES 2.0/3.0 for 3D molecule rendering
 - PDB file parsing via `kotmolpdbparser` library
-- Target SDK 36, min SDK 23, Java 11
+- Target SDK 36, min SDK 23, Java 17
 - Networking: OkHttp3 + Retrofit2
-- Image loading: Glide
+- Image loading: Glide (with KSP annotation processing) and Picasso
 - Dependencies managed via Gradle version catalog (`gradle/libs.versions.toml`)
+
+### Data Flow
+
+- **Static data** (bundled): `Corpus.kt` (MotM titles/dates), `PDBs.kt` (MOTM→PDB mappings), `MotmByCategory.kt` (categories)
+- **MotM article images**: fetched from `github.com/jimandreas/MotmImages` (self-hosted thumbnails)
+- **PDB structure files**: downloaded on demand from `files.rcsb.org/download/` via `PdbFetcherCoroutine`
+- **MotM article pages**: opened as WebView pointing to `pdb101.rcsb.org/motm/`
 
 ### Rendering Pipeline
 

--- a/captureimages/build.gradle.kts
+++ b/captureimages/build.gradle.kts
@@ -111,7 +111,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
 
     implementation(libs.timber)
-    implementation(libs.pdbparser)
+    implementation(project(":pdbparser"))
 
     testImplementation(libs.jetbrains.annotations)
     testImplementation(libs.junit.jupiter)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,7 +45,6 @@ picasso = "2.71828"
 # Utilities
 gson = "2.13.2"
 timber = "5.0.1"
-pdbparser = "1.0.5"
 muzei = "3.4.2"
 
 # Testing
@@ -93,7 +92,6 @@ picasso = { module = "com.squareup.picasso:picasso", version.ref = "picasso" }
 # Utilities
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
-pdbparser = { module = "com.kotmol.kotmolpdbparser:kotmolpdbparser", version.ref = "pdbparser" }
 muzei-api = { module = "com.google.android.apps.muzei:muzei-api", version.ref = "muzei" }
 
 # Testing

--- a/mollib/build.gradle.kts
+++ b/mollib/build.gradle.kts
@@ -72,7 +72,7 @@ dependencies {
 
     implementation(libs.timber)
     implementation(libs.okhttp)
-    implementation(libs.pdbparser)
+    implementation(project(":pdbparser"))
 
     testImplementation(libs.jetbrains.annotations)
     testImplementation(libs.junit.jupiter)

--- a/motmbrowser/build.gradle.kts
+++ b/motmbrowser/build.gradle.kts
@@ -129,7 +129,7 @@ dependencies {
     implementation(libs.retrofit)
     implementation(libs.gson)
 
-    implementation(libs.pdbparser)
+    implementation(project(":pdbparser"))
     implementation(libs.timber)
     implementation(libs.picasso)
     implementation(libs.glide)

--- a/pdbparser/build.gradle.kts
+++ b/pdbparser/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2020 Bammellab / James Andreas
+ *  Copyright 2021 James Andreas
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -11,22 +11,32 @@
  *  limitations under the License
  */
 
-pluginManagement {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
+plugins {
+    kotlin("jvm")
+    id("java-library")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-    }
+dependencies {
+    implementation(libs.kotlin.stdlib)
+
+    testImplementation(libs.junit.jupiter)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
-rootProject.name = "MotmBrowser"
-
-include(":mollib", ":motmbrowser", ":standalone", ":captureimages", ":screensaver", ":pdbparser")
+tasks.withType<Test> {
+    useJUnitPlatform()
+    testLogging {
+        events("passed", "skipped", "failed")
+    }
+}

--- a/pdbparser/src/main/java/com/kotmol/pdbParser/AtomInformationTable.kt
+++ b/pdbparser/src/main/java/com/kotmol/pdbParser/AtomInformationTable.kt
@@ -1,0 +1,160 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+        "ArrayInDataClass"
+)
+package com.kotmol.pdbParser
+
+object AtomInformationTable {
+
+    // generated from JimConvertAtomInfoTable.kt (IntelliJ Idea)
+    data class AtomNameNumber(
+            var number: Int = 0,
+            var symbol: String = "",
+            var name: String = "",
+            var vanDerWaalsRadius: Int = 300, // default size if not known
+            var color: FloatArray = floatArrayOf(0.0f, 0.0f, 0.0f, 1.0f)
+    )
+
+    val atomSymboltoAtomNumNameColor = HashMap<String, AtomNameNumber>()
+
+    val atomTable = listOf(
+            AtomNameNumber(number = 1, symbol = "H", name = "hydrogen", vanDerWaalsRadius = 120, color = floatArrayOf(1.0f, 1.0f, 1.0f, 1.0f)),
+            AtomNameNumber(number = 2, symbol = "HE", name = "helium", vanDerWaalsRadius = 140, color = floatArrayOf(0.8509804f, 1.0f, 1.0f, 1.0f)),
+            AtomNameNumber(number = 3, symbol = "LI", name = "lithium", vanDerWaalsRadius = 182, color = floatArrayOf(0.69803923f, 0.12941177f, 0.12941177f, 1.0f)),
+            AtomNameNumber(number = 4, symbol = "BE", name = "beryllium", vanDerWaalsRadius = 153, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 5, symbol = "B", name = "boron", vanDerWaalsRadius = 192, color = floatArrayOf(0.0f, 1.0f, 0.0f, 1.0f)),
+            AtomNameNumber(number = 6, symbol = "C", name = "carbon", vanDerWaalsRadius = 170, color = floatArrayOf(0.8901961f, 0.7647059f, 0.59607846f, 1.0f)),
+            AtomNameNumber(number = 7, symbol = "N", name = "nitrogen", vanDerWaalsRadius = 155, color = floatArrayOf(0.5294118f, 0.80784315f, 0.9019608f, 1.0f)),
+            AtomNameNumber(number = 8, symbol = "O", name = "oxygen", vanDerWaalsRadius = 152, color = floatArrayOf(1.0f, 0.0f, 0.0f, 1.0f)),
+            AtomNameNumber(number = 9, symbol = "F", name = "fluorine", vanDerWaalsRadius = 147, color = floatArrayOf(0.85490197f, 0.64705884f, 0.1254902f, 1.0f)),
+            AtomNameNumber(number = 10, symbol = "NE", name = "neon", vanDerWaalsRadius = 154, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 11, symbol = "NA", name = "sodium", vanDerWaalsRadius = 227, color = floatArrayOf(0.0f, 0.0f, 1.0f, 1.0f)),
+            AtomNameNumber(number = 12, symbol = "MG", name = "magnesium", vanDerWaalsRadius = 173, color = floatArrayOf(0.13333334f, 0.54509807f, 0.13333334f, 1.0f)),
+            AtomNameNumber(number = 13, symbol = "AL", name = "aluminium", vanDerWaalsRadius = 184, color = floatArrayOf(0.4117647f, 0.4117647f, 0.4117647f, 1.0f)),
+            AtomNameNumber(number = 14, symbol = "SI", name = "silicon", vanDerWaalsRadius = 210, color = floatArrayOf(0.85490197f, 0.64705884f, 0.1254902f, 1.0f)),
+            AtomNameNumber(number = 15, symbol = "P", name = "phosphorus", vanDerWaalsRadius = 180, color = floatArrayOf(1.0f, 0.6666667f, 0.0f, 1.0f)),
+            AtomNameNumber(number = 16, symbol = "S", name = "sulfur", vanDerWaalsRadius = 180, color = floatArrayOf(1.0f, 1.0f, 0.0f, 1.0f)),
+            AtomNameNumber(number = 17, symbol = "CL", name = "chlorine", vanDerWaalsRadius = 175, color = floatArrayOf(0.0f, 1.0f, 0.0f, 1.0f)),
+            AtomNameNumber(number = 18, symbol = "AR", name = "argon", vanDerWaalsRadius = 188, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 19, symbol = "K", name = "potassium", vanDerWaalsRadius = 275, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 20, symbol = "CA", name = "calcium", vanDerWaalsRadius = 231, color = floatArrayOf(0.4117647f, 0.4117647f, 0.4117647f, 1.0f)),
+            AtomNameNumber(number = 21, symbol = "SC", name = "scandium", vanDerWaalsRadius = 211, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 22, symbol = "TI", name = "titanium", vanDerWaalsRadius = 300, color = floatArrayOf(0.4117647f, 0.4117647f, 0.4117647f, 1.0f)),
+            AtomNameNumber(number = 23, symbol = "V", name = "vanadium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 24, symbol = "CR", name = "chromium", vanDerWaalsRadius = 300, color = floatArrayOf(0.4117647f, 0.4117647f, 0.4117647f, 1.0f)),
+            AtomNameNumber(number = 25, symbol = "MN", name = "manganese", vanDerWaalsRadius = 300, color = floatArrayOf(0.4117647f, 0.4117647f, 0.4117647f, 1.0f)),
+            AtomNameNumber(number = 26, symbol = "FE", name = "iron", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.6666667f, 0.0f, 1.0f)),
+            AtomNameNumber(number = 27, symbol = "CO", name = "cobalt", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 28, symbol = "NI", name = "nickel", vanDerWaalsRadius = 163, color = floatArrayOf(0.5019608f, 0.15686275f, 0.15686275f, 1.0f)),
+            AtomNameNumber(number = 29, symbol = "CU", name = "copper", vanDerWaalsRadius = 140, color = floatArrayOf(0.5019608f, 0.15686275f, 0.15686275f, 1.0f)),
+            AtomNameNumber(number = 30, symbol = "ZN", name = "zinc", vanDerWaalsRadius = 139, color = floatArrayOf(0.5019608f, 0.15686275f, 0.15686275f, 1.0f)),
+            AtomNameNumber(number = 31, symbol = "GA", name = "gallium", vanDerWaalsRadius = 187, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 32, symbol = "GE", name = "germanium", vanDerWaalsRadius = 211, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 33, symbol = "AS", name = "arsenic", vanDerWaalsRadius = 185, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 34, symbol = "SE", name = "selenium", vanDerWaalsRadius = 190, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 35, symbol = "BR", name = "bromine", vanDerWaalsRadius = 185, color = floatArrayOf(0.5019608f, 0.15686275f, 0.15686275f, 1.0f)),
+            AtomNameNumber(number = 36, symbol = "KR", name = "krypton", vanDerWaalsRadius = 202, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 37, symbol = "RB", name = "rubidium", vanDerWaalsRadius = 303, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 38, symbol = "SR", name = "strontium", vanDerWaalsRadius = 249, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 39, symbol = "Y", name = "yttrium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 40, symbol = "ZR", name = "zirconium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 41, symbol = "NB", name = "niobium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 42, symbol = "MO", name = "molybdenum", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 43, symbol = "TC", name = "technetium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 44, symbol = "RU", name = "ruthenium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 45, symbol = "RH", name = "rhodium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 46, symbol = "PD", name = "palladium", vanDerWaalsRadius = 163, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 47, symbol = "AG", name = "silver", vanDerWaalsRadius = 172, color = floatArrayOf(0.4117647f, 0.4117647f, 0.4117647f, 1.0f)),
+            AtomNameNumber(number = 48, symbol = "CD", name = "cadmium", vanDerWaalsRadius = 158, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 49, symbol = "IN", name = "indium", vanDerWaalsRadius = 193, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 50, symbol = "SN", name = "tin", vanDerWaalsRadius = 217, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 51, symbol = "SB", name = "antimony", vanDerWaalsRadius = 206, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 52, symbol = "TE", name = "tellurium", vanDerWaalsRadius = 206, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 53, symbol = "I", name = "iodine", vanDerWaalsRadius = 198, color = floatArrayOf(0.627451f, 0.1254902f, 0.9411765f, 1.0f)),
+            AtomNameNumber(number = 54, symbol = "XE", name = "xenon", vanDerWaalsRadius = 216, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 55, symbol = "CS", name = "caesium", vanDerWaalsRadius = 343, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 56, symbol = "BA", name = "barium", vanDerWaalsRadius = 268, color = floatArrayOf(1.0f, 0.6666667f, 0.0f, 1.0f)),
+            AtomNameNumber(number = 57, symbol = "LA", name = "lanthanum", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 58, symbol = "CE", name = "cerium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 59, symbol = "PR", name = "praseodymium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 60, symbol = "ND", name = "neodymium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 61, symbol = "PM", name = "promethium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 62, symbol = "SM", name = "samarium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 63, symbol = "EU", name = "europium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 64, symbol = "GD", name = "gadolinium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 65, symbol = "TB", name = "terbium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 66, symbol = "DY", name = "dysprosium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 67, symbol = "HO", name = "holmium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 68, symbol = "ER", name = "erbium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 69, symbol = "TM", name = "thulium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 70, symbol = "YB", name = "ytterbium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 71, symbol = "LU", name = "lutetium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 72, symbol = "HF", name = "hafnium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 73, symbol = "TA", name = "tantalum", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 74, symbol = "W", name = "tungsten", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 75, symbol = "RE", name = "rhenium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 76, symbol = "OS", name = "osmium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 77, symbol = "IR", name = "iridium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 78, symbol = "PT", name = "platinum", vanDerWaalsRadius = 175, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 79, symbol = "AU", name = "gold", vanDerWaalsRadius = 166, color = floatArrayOf(0.85490197f, 0.64705884f, 0.1254902f, 1.0f)),
+            AtomNameNumber(number = 80, symbol = "HG", name = "mercury", vanDerWaalsRadius = 155, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 81, symbol = "TL", name = "thallium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 82, symbol = "PB", name = "lead", vanDerWaalsRadius = 202, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 83, symbol = "BI", name = "bismuth", vanDerWaalsRadius = 207, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 84, symbol = "PO", name = "polonium", vanDerWaalsRadius = 197, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 85, symbol = "AT", name = "astatine", vanDerWaalsRadius = 202, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 86, symbol = "RN", name = "radon", vanDerWaalsRadius = 220, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 87, symbol = "FR", name = "francium", vanDerWaalsRadius = 348, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 88, symbol = "RA", name = "radium", vanDerWaalsRadius = 283, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 89, symbol = "AC", name = "actinium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 90, symbol = "TH", name = "thorium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 91, symbol = "PA", name = "protactinium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 92, symbol = "U", name = "uranium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 93, symbol = "NP", name = "neptunium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 94, symbol = "PU", name = "plutonium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 95, symbol = "AM", name = "americium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 96, symbol = "CM", name = "curium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 97, symbol = "BK", name = "berkelium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 98, symbol = "CF", name = "californium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 99, symbol = "ES", name = "einsteinium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 100, symbol = "FM", name = "fermium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 101, symbol = "MD", name = "mendelevium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 102, symbol = "NO", name = "nobelium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 103, symbol = "LR", name = "lawrencium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 104, symbol = "RF", name = "rutherfordium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 105, symbol = "DB", name = "dubnium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 106, symbol = "SG", name = "seaborgium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 107, symbol = "BH", name = "bohrium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 108, symbol = "HS", name = "hassium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 109, symbol = "MT", name = "meitnerium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 110, symbol = "DS", name = "darmstadtium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 111, symbol = "RG", name = "roentgenium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 112, symbol = "CN", name = "copernicium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 113, symbol = "UUT", name = "ununtrium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 114, symbol = "FL", name = "flerovium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 115, symbol = "UUP", name = "ununpentium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 116, symbol = "LV", name = "livermorium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 117, symbol = "UUS", name = "ununseptium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f)),
+            AtomNameNumber(number = 118, symbol = "UUO", name = "ununoctium", vanDerWaalsRadius = 300, color = floatArrayOf(1.0f, 0.078431375f, 0.5764706f, 1.0f))
+    )
+
+    init {
+        val iter = atomTable.iterator()
+        while (iter.hasNext()) {
+            val thisAtom = iter.next()
+            atomSymboltoAtomNumNameColor[thisAtom.symbol] = thisAtom
+        }
+    }
+}

--- a/pdbparser/src/main/java/com/kotmol/pdbParser/BondInfo.kt
+++ b/pdbparser/src/main/java/com/kotmol/pdbParser/BondInfo.kt
@@ -1,0 +1,909 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+
+        "MemberVisibilityCanBePrivate"
+)
+
+/*@file:Suppress(
+        "unused",
+        "unused_variable",
+        "unused_parameter",
+        "deprecation",
+        "UNUSED_ANONYMOUS_PARAMETER",
+        "UNUSED_EXPRESSION",
+        "MemberVisibilityCanBePrivate",
+        "FunctionWithLambdaExpressionBody",
+        "UnusedMainParameter",
+        "JoinDeclarationAndAssignment",
+        "CanBePrimaryConstructorProperty",
+        "RemoveEmptyClassBody",
+        "ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE",
+        "UNUSED_VALUE",
+        "ConstantConditionIf",
+        "ReplaceSingleLineLet",
+        "ReplaceJavaStaticMethodWithKotlinAnalog",
+        "NestedLambdaShadowedImplicitParameter",
+        "ArrayInDataClass" // suppresses complains about overriding equals and hashCode() operations
+)*/
+
+package com.kotmol.pdbParser
+
+/**
+ * bond information
+ *   as extracted from the database at:
+ *   @link: https://www.ebi.ac.uk/pdbe/api/pdb/compound/bonds/
+ */
+
+/**
+ *  NOTES:
+ *  from the 1992 PDB file format specification:
+ *
+ * PROTEIN DATA BANK
+ * ATOMIC COORDINATE AND BIBLIOGRAPHIC ENTRY FORMAT DESCRIPTION
+ * February 1992
+ *
+ *  Atom names employed for polynucleotides generally follow the precedents set for mononucleotides.
+ * The following points are worthy of note.
+ * (i) The prime character (') commonly used to denote atoms of the ribose originally was
+ * avoided because of non-uniformity of its external representation. An asterisk (*)
+ * therefore was used in its place, in entries released through January 1992.
+ * (ii) Of the four characters reserved for atom names the leftmost two are reserved for the
+ * chemical symbol (right justified) and the remaining two denote the atom's position.
+ * (iii) Atoms exocyclic to the ring systems have the same position identifier as the atom
+ * to which they are bonded except if this would result in identical atom names. In this
+ * case an alphabetic character is used to avoid ambiguity.
+ * (iv) The ring-oxygen atom of the ribose is denoted O4 rather than O1.
+ * (v) The extra oxygen atom at the free 5' phosphate terminus is designated OXT. This
+ * atom will be placed first in the coordinate set.
+ */
+
+class BondInfo {
+    data class KotmolBondRecord(
+            val atom_1: String,
+            val atom_2: String,
+            val bond_order: Float,
+            val bond_type: String,
+            val aromatic: Boolean = false,
+            val length: Float,
+            var bondRecordCreated: Boolean = false
+    )
+
+    val ala = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.207f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.505f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB1", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.468f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.968f
+            )
+    )
+    val arg = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.224f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.36f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.518f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.536f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.096f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.537f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.097f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.098f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "HD2", bond_order = 1f, bond_type = "sing", length = 1.095f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "HD3", bond_order = 1f, bond_type = "sing", length = 1.095f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "NE", bond_order = 1f, bond_type = "sing", length = 1.444f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD", bond_order = 1f, bond_type = "sing", length = 1.527f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG2", bond_order = 1f, bond_type = "sing", length = 1.097f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG3", bond_order = 1f, bond_type = "sing", length = 1.097f),
+            KotmolBondRecord(atom_1 = "CZ", atom_2 = "NH1", bond_order = 1f, bond_type = "sing", length = 1.391f),
+            KotmolBondRecord(atom_1 = "CZ", atom_2 = "NH2", bond_order = 2f, bond_type = "doub", length = 1.391f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.462f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 0.997f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 0.996f),
+            KotmolBondRecord(atom_1 = "NE", atom_2 = "CZ", bond_order = 1f, bond_type = "sing", length = 1.406f),
+            KotmolBondRecord(atom_1 = "NE", atom_2 = "HE", bond_order = 1f, bond_type = "sing", length = 1.027f),
+            KotmolBondRecord(atom_1 = "NH1", atom_2 = "HH11", bond_order = 1f, bond_type = "sing", length = 1.018f),
+            KotmolBondRecord(atom_1 = "NH1", atom_2 = "HH12", bond_order = 1f, bond_type = "sing", length = 1.016f),
+            KotmolBondRecord(atom_1 = "NH2", atom_2 = "HH21", bond_order = 1f, bond_type = "sing", length = 1.017f),
+            KotmolBondRecord(atom_1 = "NH2", atom_2 = "HH22", bond_order = 1f, bond_type = "sing", length = 1.017f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.981f
+            )
+    )
+    val asn = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.531f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "ND2", bond_order = 1f, bond_type = "sing", length = 1.348f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "OD1", bond_order = 2f, bond_type = "doub", length = 1.213f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.468f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "ND2", atom_2 = "HD21", bond_order = 1f, bond_type = "sing", length = 0.97f),
+            KotmolBondRecord(atom_1 = "ND2", atom_2 = "HD22", bond_order = 1f, bond_type = "sing", length = 0.97f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val asp = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.209f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.508f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "OD1", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "OD2", bond_order = 1f, bond_type = "sing", length = 1.341f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "OD2", atom_2 = "HD2", bond_order = 1f, bond_type = "sing", length = 0.966f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val asx = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB1", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "XD1", bond_order = 2f, bond_type = "doub", length = 1.642f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "XD2", bond_order = 1f, bond_type = "sing", length = 1.642f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val cys = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.207f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.343f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.506f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.528f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "SG", bond_order = 1f, bond_type = "sing", length = 1.814f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.01f),
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "SG", atom_2 = "HG", bond_order = 1f, bond_type = "sing", length = 1.344f
+            )
+    )
+    val gln = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.207f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.343f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.506f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.528f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "NE2", bond_order = 1f, bond_type = "sing", length = 1.347f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "OE1", bond_order = 2f, bond_type = "doub", length = 1.212f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG2", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "NE2", atom_2 = "HE21", bond_order = 1f, bond_type = "sing", length = 0.969f),
+            KotmolBondRecord(atom_1 = "NE2", atom_2 = "HE22", bond_order = 1f, bond_type = "sing", length = 0.97f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val glu = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.508f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.531f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "OE1", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "OE2", bond_order = 1f, bond_type = "sing", length = 1.343f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD", bond_order = 1f, bond_type = "sing", length = 1.508f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG3", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "OE2", atom_2 = "HE2", bond_order = 1f, bond_type = "sing", length = 0.966f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val glx = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.343f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.531f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB1", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "XE1", bond_order = 2f, bond_type = "doub", length = 1.642f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "XE2", bond_order = 1f, bond_type = "sing", length = 1.642f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD", bond_order = 1f, bond_type = "sing", length = 1.506f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG1", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "HXT", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f
+            )
+    )
+    val gly = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.47f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val his = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.227f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.355f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.522f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.534f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.096f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.51f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.099f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.098f),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "HD2", bond_order = 1f, bond_type = "sing", length = 1.072f),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "NE2", bond_order = 1.5f, bond_type = "sing", length = 1.374f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CE1", atom_2 = "HE1", bond_order = 1f, bond_type = "sing", length = 1.078f),
+            KotmolBondRecord(atom_1 = "CE1", atom_2 = "NE2", bond_order = 1.5f, bond_type = "sing", length = 1.337f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD2", bond_order = 1.5f, bond_type = "doub", length = 1.338f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "ND1", bond_order = 1.5f, bond_type = "sing", length = 1.351f, aromatic = true),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.441f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.006f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.007f),
+            KotmolBondRecord(atom_1 = "ND1", atom_2 = "CE1", bond_order = 1.5f, bond_type = "doub", length = 1.337f, aromatic = true),
+            KotmolBondRecord(atom_1 = "ND1", atom_2 = "HD1", bond_order = 1f, bond_type = "sing", length = 1.016f),
+            KotmolBondRecord(atom_1 = "NE2", atom_2 = "HE2", bond_order = 1f, bond_type = "sing", length = 1.016f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.98f
+            )
+    )
+    val ile = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.506f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG1", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG2", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "HD11", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "HD12", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "HD13", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG1", atom_2 = "CD1", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CG1", atom_2 = "HG12", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG1", atom_2 = "HG13", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG2", atom_2 = "HG21", bond_order = 1f, bond_type = "sing", length = 1.088f),
+            KotmolBondRecord(atom_1 = "CG2", atom_2 = "HG22", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG2", atom_2 = "HG23", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.007f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+
+    val leu = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.343f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.506f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "HD11", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "HD12", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "HD13", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "HD21", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "HD22", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "HD23", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD1", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD2", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.966f
+            )
+    )
+    val lys = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.343f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.531f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "CE", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "HD2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "HD3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CE", atom_2 = "HE2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CE", atom_2 = "HE3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CE", atom_2 = "NZ", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD", bond_order = 1f, bond_type = "sing", length = 1.531f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG2", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "NZ", atom_2 = "HZ1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "NZ", atom_2 = "HZ2", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "NZ", atom_2 = "HZ3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val met = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.207f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.343f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.506f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.528f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "CE", atom_2 = "HE1", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CE", atom_2 = "HE2", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CE", atom_2 = "HE3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "SD", bond_order = 1f, bond_type = "sing", length = 1.814f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.01f),
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "SD", atom_2 = "CE", bond_order = 1f, bond_type = "sing", length = 1.814f
+            )
+    )
+    val phe = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.207f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.341f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.505f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "CE1", bond_order = 1.5f, bond_type = "sing", length = 1.382f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "HD1", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "CE2", bond_order = 1.5f, bond_type = "doub", length = 1.382f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "HD2", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "CE1", atom_2 = "CZ", bond_order = 1.5f, bond_type = "doub", length = 1.381f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CE1", atom_2 = "HE1", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "CE2", atom_2 = "CZ", bond_order = 1.5f, bond_type = "sing", length = 1.382f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CE2", atom_2 = "HE2", bond_order = 1f, bond_type = "sing", length = 1.081f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD1", bond_order = 1.5f, bond_type = "doub", length = 1.382f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD2", bond_order = 1.5f, bond_type = "sing", length = 1.383f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CZ", atom_2 = "HZ", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val pro = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.508f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.543f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.543f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "HD2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CD", atom_2 = "HD3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD", bond_order = 1f, bond_type = "sing", length = 1.544f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "HG3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.486f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CD", bond_order = 1f, bond_type = "sing", length = 1.487f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.966f
+            )
+    )
+    val ser = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.207f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "OG", bond_order = 1f, bond_type = "sing", length = 1.428f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "OG", atom_2 = "HG", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val thr = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.207f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.506f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG2", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "OG1", bond_order = 1f, bond_type = "sing", length = 1.428f),
+            KotmolBondRecord(atom_1 = "CG2", atom_2 = "HG21", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CG2", atom_2 = "HG22", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG2", atom_2 = "HG23", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.007f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "OG1", atom_2 = "HG1", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val trp = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "HD1", bond_order = 1f, bond_type = "sing", length = 1.079f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "NE1", bond_order = 1.5f, bond_type = "sing", length = 1.369f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "CE2", bond_order = 1.5f, bond_type = "doub", length = 1.407f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "CE3", bond_order = 1.5f, bond_type = "sing", length = 1.396f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CE2", atom_2 = "CZ2", bond_order = 1.5f, bond_type = "sing", length = 1.391f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CE3", atom_2 = "CZ3", bond_order = 1.5f, bond_type = "doub", length = 1.366f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CE3", atom_2 = "HE3", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD1", bond_order = 1.5f, bond_type = "doub", length = 1.343f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD2", bond_order = 1.5f, bond_type = "sing", length = 1.464f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CH2", atom_2 = "HH2", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "CZ2", atom_2 = "CH2", bond_order = 1.5f, bond_type = "doub", length = 1.377f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CZ2", atom_2 = "HZ2", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "CZ3", atom_2 = "CH2", bond_order = 1.5f, bond_type = "sing", length = 1.388f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CZ3", atom_2 = "HZ3", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.01f),
+            KotmolBondRecord(atom_1 = "NE1", atom_2 = "CE2", bond_order = 1.5f, bond_type = "sing", length = 1.377f, aromatic = true),
+            KotmolBondRecord(atom_1 = "NE1", atom_2 = "HE1", bond_order = 1f, bond_type = "sing", length = 0.969f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+    val tyr = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.207f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.507f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG", bond_order = 1f, bond_type = "sing", length = 1.506f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB2", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB3", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "CE1", bond_order = 1.5f, bond_type = "sing", length = 1.381f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CD1", atom_2 = "HD1", bond_order = 1f, bond_type = "sing", length = 1.079f),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "CE2", bond_order = 1.5f, bond_type = "doub", length = 1.381f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CD2", atom_2 = "HD2", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "CE1", atom_2 = "CZ", bond_order = 1.5f, bond_type = "doub", length = 1.387f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CE1", atom_2 = "HE1", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "CE2", atom_2 = "CZ", bond_order = 1.5f, bond_type = "sing", length = 1.388f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CE2", atom_2 = "HE2", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD1", bond_order = 1.5f, bond_type = "doub", length = 1.382f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CG", atom_2 = "CD2", bond_order = 1.5f, bond_type = "sing", length = 1.383f, aromatic = true),
+            KotmolBondRecord(atom_1 = "CZ", atom_2 = "OH", bond_order = 1f, bond_type = "sing", length = 1.358f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "OH", atom_2 = "HH", bond_order = 1f, bond_type = "sing", length = 0.966f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.968f
+            )
+    )
+    val valine = listOf(
+            KotmolBondRecord(atom_1 = "C", atom_2 = "O", bond_order = 2f, bond_type = "doub", length = 1.208f),
+            KotmolBondRecord(atom_1 = "C", atom_2 = "OXT", bond_order = 1f, bond_type = "sing", length = 1.342f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "C", bond_order = 1f, bond_type = "sing", length = 1.506f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "CB", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CA", atom_2 = "HA", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG1", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "CG2", bond_order = 1f, bond_type = "sing", length = 1.529f),
+            KotmolBondRecord(atom_1 = "CB", atom_2 = "HB", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "CG1", atom_2 = "HG11", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG1", atom_2 = "HG12", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG1", atom_2 = "HG13", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "CG2", atom_2 = "HG21", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG2", atom_2 = "HG22", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "CG2", atom_2 = "HG23", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "CA", bond_order = 1f, bond_type = "sing", length = 1.469f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H", bond_order = 1f, bond_type = "sing", length = 1.008f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // add H1 and H3 bonds to N
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            KotmolBondRecord(atom_1 = "N", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.009f),
+            // end change
+            KotmolBondRecord(atom_1 = "OXT", atom_2 = "HXT", bond_order = 1f, bond_type = "sing", length = 0.967f
+            )
+    )
+
+    val da = listOf(
+            /*
+             *   !!!
+             * These two records were added to capture the bond between the
+             * C2' then O2' and HO2'
+             * this was borrowed from another bond between an OXT and HXT
+             * SEE: 1A1T.pdb
+             */
+            KotmolBondRecord(atom_1 = "O2'", atom_2 = "HO2'", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "O2'", bond_order = 1f, bond_type = "sing", length = 1.43f),
+            /*
+             *  End of added record
+             */
+
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "H1'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "N9", bond_order = 1f, bond_type = "sing", length = 1.466f),
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "H2", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "N3", bond_order = 1.5f, bond_type = "doub", length = 1.316f, aromatic = true),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.541f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2'", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2''", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "C2'", bond_order = 1f, bond_type = "sing", length = 1.547f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "H3'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "O3'", bond_order = 1f, bond_type = "sing", length = 1.429f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "C3'", bond_order = 1f, bond_type = "sing", length = 1.549f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "H4'", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "O4'", bond_order = 1f, bond_type = "sing", length = 1.446f),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "C4", bond_order = 1.5f, bond_type = "doub", length = 1.405f, aromatic = true),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "C6", bond_order = 1.5f, bond_type = "sing", length = 1.405f, aromatic = true),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "C4'", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5''", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "C6", atom_2 = "N1", bond_order = 1.5f, bond_type = "doub", length = 1.329f, aromatic = true),
+            KotmolBondRecord(atom_1 = "C6", atom_2 = "N6", bond_order = 1f, bond_type = "sing", length = 1.384f),
+            KotmolBondRecord(atom_1 = "C8", atom_2 = "H8", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "C8", atom_2 = "N7", bond_order = 1.5f, bond_type = "doub", length = 1.301f, aromatic = true),
+            KotmolBondRecord(atom_1 = "N1", atom_2 = "C2", bond_order = 1.5f, bond_type = "sing", length = 1.319f, aromatic = true),
+            KotmolBondRecord(atom_1 = "N3", atom_2 = "C4", bond_order = 1.5f, bond_type = "sing", length = 1.329f, aromatic = true),
+            KotmolBondRecord(atom_1 = "N6", atom_2 = "H61", bond_order = 1f, bond_type = "sing", length = 0.97f),
+            KotmolBondRecord(atom_1 = "N6", atom_2 = "H62", bond_order = 1f, bond_type = "sing", length = 0.971f),
+            KotmolBondRecord(atom_1 = "N7", atom_2 = "C5", bond_order = 1.5f, bond_type = "sing", length = 1.355f, aromatic = true),
+            KotmolBondRecord(atom_1 = "N9", atom_2 = "C4", bond_order = 1.5f, bond_type = "sing", length = 1.372f, aromatic = true),
+            KotmolBondRecord(atom_1 = "N9", atom_2 = "C8", bond_order = 1.5f, bond_type = "sing", length = 1.362f, aromatic = true),
+            KotmolBondRecord(atom_1 = "O3'", atom_2 = "HO3'", bond_order = 1f, bond_type = "sing", length = 0.966f),
+            KotmolBondRecord(atom_1 = "O4'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.436f),
+            KotmolBondRecord(atom_1 = "O5'", atom_2 = "C5'", bond_order = 1f, bond_type = "sing", length = 1.428f),
+            KotmolBondRecord(atom_1 = "OP2", atom_2 = "HOP2", bond_order = 1f, bond_type = "sing", length = 0.966f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "HOP3", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "P", bond_order = 1f, bond_type = "sing", length = 1.61f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "O5'", bond_order = 1f, bond_type = "sing", length = 1.609f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP1", bond_order = 2f, bond_type = "doub", length = 1.48f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP2", bond_order = 1f, bond_type = "sing", length = 1.61f
+            )
+    )
+    val dc = listOf(
+            /*
+             *   !!!
+             * These two records were added to capture the bond between the
+             * C2' then O2' and HO2'
+             * this was borrowed from another bond between an OXT and HXT
+             * SEE: 1A1T.pdb
+             */
+            KotmolBondRecord(atom_1 = "O2'", atom_2 = "HO2'", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "O2'", bond_order = 1f, bond_type = "sing", length = 1.43f),
+            /*
+             *  End of added record
+             */
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "H1'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "N1", bond_order = 1f, bond_type = "sing", length = 1.465f),
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "N3", bond_order = 1f, bond_type = "sing", length = 1.332f),
+             /*  BUG should be O2
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "O2'", bond_order = 2f, bond_type = "doub", length = 1.22f),
+              */
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "O2", bond_order = 2f, bond_type = "doub", length = 1.22f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.541f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2'", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2''", bond_order = 1f, bond_type = "sing", length = 1.091f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "C2'", bond_order = 1f, bond_type = "sing", length = 1.547f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "H3'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "O3'", bond_order = 1f, bond_type = "sing", length = 1.429f),
+            KotmolBondRecord(atom_1 = "C4", atom_2 = "C5", bond_order = 1f, bond_type = "sing", length = 1.41f),
+            KotmolBondRecord(atom_1 = "C4", atom_2 = "N4", bond_order = 1f, bond_type = "sing", length = 1.376f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "C3'", bond_order = 1f, bond_type = "sing", length = 1.549f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "H4'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "O4'", bond_order = 1f, bond_type = "sing", length = 1.445f),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "C6", bond_order = 2f, bond_type = "doub", length = 1.353f),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "H5", bond_order = 1f, bond_type = "sing", length = 1.081f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "C4'", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5''", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "C6", atom_2 = "H6", bond_order = 1f, bond_type = "sing", length = 1.08f),
+            KotmolBondRecord(atom_1 = "N1", atom_2 = "C2", bond_order = 1f, bond_type = "sing", length = 1.344f),
+            KotmolBondRecord(atom_1 = "N1", atom_2 = "C6", bond_order = 1f, bond_type = "sing", length = 1.362f),
+            KotmolBondRecord(atom_1 = "N3", atom_2 = "C4", bond_order = 2f, bond_type = "doub", length = 1.326f),
+            KotmolBondRecord(atom_1 = "N4", atom_2 = "H41", bond_order = 1f, bond_type = "sing", length = 0.97f),
+            KotmolBondRecord(atom_1 = "N4", atom_2 = "H42", bond_order = 1f, bond_type = "sing", length = 0.97f),
+            KotmolBondRecord(atom_1 = "O3'", atom_2 = "HO3'", bond_order = 1f, bond_type = "sing", length = 0.968f),
+            KotmolBondRecord(atom_1 = "O4'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.437f),
+            KotmolBondRecord(atom_1 = "O5'", atom_2 = "C5'", bond_order = 1f, bond_type = "sing", length = 1.428f),
+            KotmolBondRecord(atom_1 = "OP2", atom_2 = "HOP2", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "HOP3", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "P", bond_order = 1f, bond_type = "sing", length = 1.61f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "O5'", bond_order = 1f, bond_type = "sing", length = 1.611f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP1", bond_order = 2f, bond_type = "doub", length = 1.48f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP2", bond_order = 1f, bond_type = "sing", length = 1.609f
+            )
+    )
+    val dg = listOf(
+            /*
+             *   !!!
+             * These two records were added to capture the bond between the
+             * C2' then O2' and HO2'
+             * this was borrowed from another bond between an OXT and HXT
+             * SEE: 1A1T.pdb
+             */
+            KotmolBondRecord(atom_1 = "O2'", atom_2 = "HO2'", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "O2'", bond_order = 1f, bond_type = "sing", length = 1.43f),
+            /*
+             *  End of added record
+             */
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "H1'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "N9", bond_order = 1f, bond_type = "sing", length = 1.464f),
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "N2", bond_order = 1f, bond_type = "sing", length = 1.372f),
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "N3", bond_order = 2f, bond_type = "doub", length = 1.314f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.54f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2''", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "C2'", bond_order = 1f, bond_type = "sing", length = 1.547f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "H3'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "O3'", bond_order = 1f, bond_type = "sing", length = 1.43f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "C3'", bond_order = 1f, bond_type = "sing", length = 1.55f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "H4'", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "O4'", bond_order = 1f, bond_type = "sing", length = 1.446f),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "C4", bond_order = 1.5f, bond_type = "doub", length = 1.4f, aromatic = true),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "C6", bond_order = 1f, bond_type = "sing", length = 1.415f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "C4'", bond_order = 1f, bond_type = "sing", length = 1.53f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5'", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5''", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C6", atom_2 = "N1", bond_order = 1f, bond_type = "sing", length = 1.351f),
+            KotmolBondRecord(atom_1 = "C6", atom_2 = "O6", bond_order = 2f, bond_type = "doub", length = 1.219f),
+            KotmolBondRecord(atom_1 = "C8", atom_2 = "H8", bond_order = 1f, bond_type = "sing", length = 1.081f),
+            KotmolBondRecord(atom_1 = "C8", atom_2 = "N7", bond_order = 1.5f, bond_type = "doub", length = 1.302f, aromatic = true),
+            KotmolBondRecord(atom_1 = "N1", atom_2 = "C2", bond_order = 1f, bond_type = "sing", length = 1.362f),
+            KotmolBondRecord(atom_1 = "N1", atom_2 = "H1", bond_order = 1f, bond_type = "sing", length = 0.97f),
+            KotmolBondRecord(atom_1 = "N2", atom_2 = "H21", bond_order = 1f, bond_type = "sing", length = 0.97f),
+            KotmolBondRecord(atom_1 = "N2", atom_2 = "H22", bond_order = 1f, bond_type = "sing", length = 0.97f),
+            KotmolBondRecord(atom_1 = "N3", atom_2 = "C4", bond_order = 1f, bond_type = "sing", length = 1.338f),
+            KotmolBondRecord(atom_1 = "N7", atom_2 = "C5", bond_order = 1.5f, bond_type = "sing", length = 1.355f, aromatic = true),
+            KotmolBondRecord(atom_1 = "N9", atom_2 = "C4", bond_order = 1.5f, bond_type = "sing", length = 1.368f, aromatic = true),
+            KotmolBondRecord(atom_1 = "N9", atom_2 = "C8", bond_order = 1.5f, bond_type = "sing", length = 1.364f, aromatic = true),
+            KotmolBondRecord(atom_1 = "O3'", atom_2 = "HO3'", bond_order = 1f, bond_type = "sing", length = 0.966f),
+            KotmolBondRecord(atom_1 = "O4'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.437f),
+            KotmolBondRecord(atom_1 = "O5'", atom_2 = "C5'", bond_order = 1f, bond_type = "sing", length = 1.428f),
+            KotmolBondRecord(atom_1 = "OP2", atom_2 = "HOP2", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "HOP3", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "P", bond_order = 1f, bond_type = "sing", length = 1.611f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "O5'", bond_order = 1f, bond_type = "sing", length = 1.61f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP1", bond_order = 2f, bond_type = "doub", length = 1.479f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP2", bond_order = 1f, bond_type = "sing", length = 1.608f
+            )
+    )
+    val dt = listOf(
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "H1'", bond_order = 1f, bond_type = "sing", length = 1.095f),
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "N1", bond_order = 1f, bond_type = "sing", length = 1.434f),
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "N3", bond_order = 1f, bond_type = "sing", length = 1.399f),
+            /* BUG should be O2
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "O2'", bond_order = 2f, bond_type = "doub", length = 1.232f),
+            */
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "O2", bond_order = 2f, bond_type = "doub", length = 1.232f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.52f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2'", bond_order = 1f, bond_type = "sing", length = 1.097f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2''", bond_order = 1f, bond_type = "sing", length = 1.095f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "C2'", bond_order = 1f, bond_type = "sing", length = 1.511f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "H3'", bond_order = 1f, bond_type = "sing", length = 1.094f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "O3'", bond_order = 1f, bond_type = "sing", length = 1.426f),
+            KotmolBondRecord(atom_1 = "C4", atom_2 = "C5", bond_order = 1f, bond_type = "sing", length = 1.487f),
+            KotmolBondRecord(atom_1 = "C4", atom_2 = "O4", bond_order = 2f, bond_type = "doub", length = 1.228f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "C3'", bond_order = 1f, bond_type = "sing", length = 1.522f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "H4'", bond_order = 1f, bond_type = "sing", length = 1.094f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "O4'", bond_order = 1f, bond_type = "sing", length = 1.441f),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "C6", bond_order = 2f, bond_type = "doub", length = 1.339f),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "C7", bond_order = 1f, bond_type = "sing", length = 1.495f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "C4'", bond_order = 1f, bond_type = "sing", length = 1.523f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5'", bond_order = 1f, bond_type = "sing", length = 1.092f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5''", bond_order = 1f, bond_type = "sing", length = 1.093f),
+            KotmolBondRecord(atom_1 = "C6", atom_2 = "H6", bond_order = 1f, bond_type = "sing", length = 1.086f),
+            KotmolBondRecord(atom_1 = "C7", atom_2 = "H71", bond_order = 1f, bond_type = "sing", length = 1.089f),
+            KotmolBondRecord(atom_1 = "C7", atom_2 = "H72", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "C7", atom_2 = "H73", bond_order = 1f, bond_type = "sing", length = 1.09f),
+            KotmolBondRecord(atom_1 = "N1", atom_2 = "C2", bond_order = 1f, bond_type = "sing", length = 1.411f),
+            KotmolBondRecord(atom_1 = "N1", atom_2 = "C6", bond_order = 1f, bond_type = "sing", length = 1.389f),
+            KotmolBondRecord(atom_1 = "N3", atom_2 = "C4", bond_order = 1f, bond_type = "sing", length = 1.387f),
+            KotmolBondRecord(atom_1 = "N3", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.016f),
+            KotmolBondRecord(atom_1 = "O3'", atom_2 = "HO3'", bond_order = 1f, bond_type = "sing", length = 0.973f),
+            KotmolBondRecord(atom_1 = "O4'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.434f),
+            KotmolBondRecord(atom_1 = "O5'", atom_2 = "C5'", bond_order = 1f, bond_type = "sing", length = 1.418f),
+            KotmolBondRecord(atom_1 = "OP2", atom_2 = "HOP2", bond_order = 1f, bond_type = "sing", length = 0.981f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "HOP3", bond_order = 1f, bond_type = "sing", length = 0.981f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "P", bond_order = 1f, bond_type = "sing", length = 1.618f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "O5'", bond_order = 1f, bond_type = "sing", length = 1.619f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP1", bond_order = 2f, bond_type = "doub", length = 1.501f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP2", bond_order = 1f, bond_type = "sing", length = 1.616f
+            )
+    )
+    val du = listOf(
+            /*
+             *   !!!
+             * These two records were added to capture the bond between the
+             * C2' then O2' and HO2'
+             * this was borrowed from another bond between an OXT and HXT
+             * SEE: 1A1T.pdb
+             */
+            KotmolBondRecord(atom_1 = "O2'", atom_2 = "HO2'", bond_order = 1f, bond_type = "sing", length = 0.967f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "O2'", bond_order = 1f, bond_type = "sing", length = 1.43f),
+            /*
+             *  End of added record
+             */
+
+
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "H1'", bond_order = 1f, bond_type = "sing", length = 1.095f),
+            KotmolBondRecord(atom_1 = "C1'", atom_2 = "N1", bond_order = 1f, bond_type = "sing", length = 1.434f),
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "N3", bond_order = 1f, bond_type = "sing", length = 1.402f),
+            /* BUG should be O2
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "O2'", bond_order = 2f, bond_type = "doub", length = 1.233f),
+            */
+            KotmolBondRecord(atom_1 = "C2", atom_2 = "O2", bond_order = 2f, bond_type = "doub", length = 1.233f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.52f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2'", bond_order = 1f, bond_type = "sing", length = 1.097f),
+            KotmolBondRecord(atom_1 = "C2'", atom_2 = "H2''", bond_order = 1f, bond_type = "sing", length = 1.095f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "C2'", bond_order = 1f, bond_type = "sing", length = 1.511f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "H3'", bond_order = 1f, bond_type = "sing", length = 1.094f),
+            KotmolBondRecord(atom_1 = "C3'", atom_2 = "O3'", bond_order = 1f, bond_type = "sing", length = 1.426f),
+            KotmolBondRecord(atom_1 = "C4", atom_2 = "C5", bond_order = 1f, bond_type = "sing", length = 1.477f),
+            KotmolBondRecord(atom_1 = "C4", atom_2 = "O4", bond_order = 2f, bond_type = "doub", length = 1.227f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "C3'", bond_order = 1f, bond_type = "sing", length = 1.522f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "H4'", bond_order = 1f, bond_type = "sing", length = 1.094f),
+            KotmolBondRecord(atom_1 = "C4'", atom_2 = "O4'", bond_order = 1f, bond_type = "sing", length = 1.441f),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "C6", bond_order = 2f, bond_type = "doub", length = 1.336f),
+            KotmolBondRecord(atom_1 = "C5", atom_2 = "H5", bond_order = 1f, bond_type = "sing", length = 1.083f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "C4'", bond_order = 1f, bond_type = "sing", length = 1.523f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5'", bond_order = 1f, bond_type = "sing", length = 1.092f),
+            KotmolBondRecord(atom_1 = "C5'", atom_2 = "H5''", bond_order = 1f, bond_type = "sing", length = 1.093f),
+            KotmolBondRecord(atom_1 = "C6", atom_2 = "H6", bond_order = 1f, bond_type = "sing", length = 1.085f),
+            KotmolBondRecord(atom_1 = "N1", atom_2 = "C2", bond_order = 1f, bond_type = "sing", length = 1.412f),
+            KotmolBondRecord(atom_1 = "N1", atom_2 = "C6", bond_order = 1f, bond_type = "sing", length = 1.389f),
+            KotmolBondRecord(atom_1 = "N3", atom_2 = "C4", bond_order = 1f, bond_type = "sing", length = 1.386f),
+            KotmolBondRecord(atom_1 = "N3", atom_2 = "H3", bond_order = 1f, bond_type = "sing", length = 1.016f),
+            KotmolBondRecord(atom_1 = "O3'", atom_2 = "HO3'", bond_order = 1f, bond_type = "sing", length = 0.973f),
+            KotmolBondRecord(atom_1 = "O4'", atom_2 = "C1'", bond_order = 1f, bond_type = "sing", length = 1.434f),
+            KotmolBondRecord(atom_1 = "O5'", atom_2 = "C5'", bond_order = 1f, bond_type = "sing", length = 1.418f),
+            KotmolBondRecord(atom_1 = "OP2", atom_2 = "HOP2", bond_order = 1f, bond_type = "sing", length = 0.981f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "HOP3", bond_order = 1f, bond_type = "sing", length = 0.981f),
+            KotmolBondRecord(atom_1 = "OP3", atom_2 = "P", bond_order = 1f, bond_type = "sing", length = 1.618f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "O5'", bond_order = 1f, bond_type = "sing", length = 1.619f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP1", bond_order = 2f, bond_type = "doub", length = 1.501f),
+            KotmolBondRecord(atom_1 = "P", atom_2 = "OP2", bond_order = 1f, bond_type = "sing", length = 1.616f
+            )
+    )
+
+
+    val kotmolBondLookup = hashMapOf(
+            "ala" to ala, "arg" to arg, "asn" to asn, "asp" to asp, "asx" to asx, "cys" to cys, "glu" to glu, "gln" to gln, "glx" to glx, "gly" to gly, "his" to his, "ile" to ile, "leu" to leu, "lys" to lys, "met" to met, "phe" to phe, "pro" to pro, "ser" to ser, "thr" to thr, "trp" to trp, "tyr" to tyr, "val" to valine, // nucleic acid bonds
+            "da" to da, "dc" to dc, "dg" to dg, "dt" to dt, "du" to du, "a" to da, "c" to dc, "g" to dg, "t" to dt, "u" to du
+    )
+
+}

--- a/pdbparser/src/main/java/com/kotmol/pdbParser/ChainRenderingDescriptor.kt
+++ b/pdbparser/src/main/java/com/kotmol/pdbParser/ChainRenderingDescriptor.kt
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+        "unused",
+        "unused_variable",
+        "unused_parameter",
+        "unused_property",
+        "deprecation",
+        "ConstantConditionIf",
+        "LocalVariableName",
+        "PropertyName")
+package com.kotmol.pdbParser
+
+import com.kotmol.pdbParser.ChainRenderingDescriptor.SecondaryStructureType.RIBBON
+
+/**
+ * this records information used in rendering the CA ribbon for the
+ * various chains - Alpha, Beta, and Nucleic
+ */
+class ChainRenderingDescriptor {
+    var secondaryStructureType = RIBBON
+
+    var backboneAtom: PdbAtom? = null
+    var guideAtom: PdbAtom? = null
+    var startAtom: PdbAtom? = null
+    var endAtom: PdbAtom? = null
+    // use the C3' atom to extend the spline just a bit
+    lateinit var nucleicEndAtom: PdbAtom
+
+    var curveIndex: Int = 0
+
+    var endOfSecondaryStructure = false
+
+    var nucleicType = NucleicType.NOT_A_NUCLEIC_TYPE
+
+    var nucleicCornerAtom: PdbAtom? = null
+    var nucleicGuideAtom: PdbAtom? = null
+    var nucleicPlanarAtom: PdbAtom? = null
+
+    enum class SecondaryStructureType {
+        RIBBON,
+        ALPHA_HELIX,
+        BETA_SHEET,
+        NUCLEIC,
+        NOT_A_SECONDARY_STRUCTURE_TYPE
+    }
+
+    enum class NucleicType {
+        PURINE,
+        PYRIMIDINE,
+        NOT_A_NUCLEIC_TYPE
+    }
+
+}

--- a/pdbparser/src/main/java/com/kotmol/pdbParser/Molecule.kt
+++ b/pdbparser/src/main/java/com/kotmol/pdbParser/Molecule.kt
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2021 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+        "unused", "unused_variable", "unused_parameter", "UNUSED_ANONYMOUS_PARAMETER", "UNUSED_EXPRESSION",
+        "UnusedMainParameter",
+        "deprecation","MemberVisibilityCanBePrivate",
+        "FunctionWithLambdaExpressionBody",
+        "JoinDeclarationAndAssignment",
+        "CanBePrimaryConstructorProperty", "RemoveEmptyClassBody",
+        "ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE", "UNUSED_VALUE",
+        "ConstantConditionIf", "ReplaceSingleLineLet",
+        "ReplaceJavaStaticMethodWithKotlinAnalog",
+        "NestedLambdaShadowedImplicitParameter"
+)
+
+package com.kotmol.pdbParser
+
+import java.util.*
+
+class Molecule {
+    var molName: String = ""
+    val averagePosition = KotmolVector3()
+    var maxPostCenteringVectorMagnitude = 0.0f
+    var maxPostCenteringCoordinate = KotmolVector3()
+    val atomNumberList: MutableList<Int> = ArrayList()
+    val atomNumberToAtomInfoHash = HashMap<Int, PdbAtom>()
+    var maxAtomNumber: Int = 0
+    //var maxCoordinate: Float = 0.0
+    val terRecordTest = HashMap<Int, Boolean>()
+    val bondList: MutableList<Bond> = ArrayList()
+    val helixList: MutableList<PdbHelix> = ArrayList()
+    val pdbSheetList: MutableList<PdbBetaSheet> = ArrayList()
+    val listofChainDescriptorLists: MutableList<List<ChainRenderingDescriptor>> = ArrayList()
+    private val listofDnaHelixChainLists: MutableList<List<ChainRenderingDescriptor>> = ArrayList()
+    var ribbonNodeCount = 0
+    var unbondedAtomCount = 0
+    var hasAlternateLocations = false
+    var guideAtomMissing = false
+
+    // TODO: parse multiple MODELs
+    /*
+     * this is a placeholder for the API to hold an array of additional MODELs
+     * as defined in an NMR type PDB file.  If this is implemented, then
+     * the additional MODELs would appear here as a list of additional Molecules()
+     */
+    val modelArray: MutableList<Molecule>? = null
+    val modelNumber : Int? = null
+
+    /*
+     * list of ribbons to render
+     *    pretty simple just yet
+     */
+    var listofRibbonLists: List<List<*>> = ArrayList()
+
+    fun clearLists() {
+        maxAtomNumber = 0
+        atomNumberList.clear()
+        atomNumberToAtomInfoHash.clear()
+        bondList.clear()
+        helixList.clear()
+        pdbSheetList.clear()
+        listofChainDescriptorLists.clear()
+        listofDnaHelixChainLists.clear()
+        ribbonNodeCount = 0
+        modelArray?.clear()
+    }
+
+}
+
+enum class BondType {
+    BONDTABLE, CONECT
+}
+class Bond(val atomNumber1: Int, val atomNumber2: Int, var type: BondType = BondType.BONDTABLE)

--- a/pdbparser/src/main/java/com/kotmol/pdbParser/ParserPdbFile.kt
+++ b/pdbparser/src/main/java/com/kotmol/pdbParser/ParserPdbFile.kt
@@ -1,0 +1,1327 @@
+/*
+ *  Copyright 2021 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+        "unused",
+        "unused_variable",
+        "unused_parameter",
+        "deprecation",
+        "UNUSED_ANONYMOUS_PARAMETER",
+        "UNUSED_EXPRESSION",
+        "MemberVisibilityCanBePrivate", "FunctionWithLambdaExpressionBody",
+        "UnusedMainParameter", "JoinDeclarationAndAssignment",
+        "CanBePrimaryConstructorProperty", "RemoveEmptyClassBody")
+
+package com.kotmol.pdbParser
+import java.util.*
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+
+/**
+ * @author Jim Andreas
+ * @email jim@kotmol.com
+ * @link <a href='http://jcouture.net/cisc190/A19002.php'>Program Specification</a>
+ * @link <br><a href='>https://github.com/kotmol/KotmolPdbParser</a>
+ *
+ * Notes:
+ * Use of UNX/UNL/UNK There are times when an amino acid residue, nucleotide, atom, or ligand is unidentified. These ligand codes should be used in the following cases:
+
+    UNX: unknown atom or ion
+    UNL: unknown ligand
+    UNK: unknown amino acid
+    N: unknown nucleotide
+     @link https://www.wwpdb.org/documentation/procedure
+
+ */
+
+// TODO: parse old version of Hydrogen atoms (e.g. 1HD)
+// TODO: parse HETATM - convert "CO" in 1mat to single letter code (at atom 1967)
+
+class ParserPdbFile internal constructor( builder: Builder ) {
+
+    constructor(mol: Molecule) : this(Builder(mol))
+
+    class Builder(private val mol: Molecule) {
+
+        //private lateinit var mol: Molecule
+        private val bondinfo = BondInfo()
+
+        private var averageX = 0.0f
+        private var averageY = 0.0f
+        private var averageZ = 0.0f
+        private lateinit var messageStrings: MutableList<String>
+        private var parseModelsSomeday = false
+        private var centerTheMoleculeCoordinatesFlag = true
+        private var doBondProcessing = true
+        private lateinit var inputStream: InputStream
+        private val encodedBondMap: MutableMap<Int, Boolean> = mutableMapOf(0 to false)
+
+        /**
+         * Pass in a string list if you want some logging.
+         * There is no inherent logging facility besides the
+         * messages appended to a string list.
+         *
+         * @param messagesIn - an optional parameter for parsing.
+         */
+        fun setMessageStrings(messagesIn: MutableList<String>) = apply {
+            messageStrings = messagesIn
+        }
+
+        /**
+         * If you want to annotate the logging with the name (e.g. 1BNA) of
+         * the molecule that will be parsed, pass it in here.
+         * TODO: make sure that all message strings contain the filename
+         * (not completely implemented yet)
+         */
+        fun setMoleculeName(molNameString: String) = apply {
+            mol.molName = molNameString
+        }
+
+        /**
+         * The processing of bond information is optional.   The default
+         * mode is `true` - but it can be suppressed if you just want
+         * `ATOM` and `HETATM` information
+         */
+        fun doBondProcessing(bool: Boolean) = apply {
+            doBondProcessing = bool
+        }
+
+        /**
+         * optionally parse multiple models.
+         */
+        fun parseModels(parseModelFlag: Boolean) = apply {
+            parseModelsSomeday = parseModelFlag
+            // TODO: optionally parse additional models if flag is set
+            if (parseModelFlag) {
+                TODO() // well someday
+            }
+            messageStrings.add(
+                    String.format(
+                            "%sparsing: parsing of MODELs is not yet implemented.",
+                            messageMolName()))
+        }
+
+        /**
+         * there is no guarantee that the PDB atom coordinates will be centered -
+         * they can be somewhere off to one side or the PDB file may contain
+         * some subset of residues away from the center of the molecule.
+         * The default is to use the average of the coordinate atom position data
+         * to center the molecule around the x, y, and z coordinate axes.
+         */
+        fun centerTheMolecule(centerTheMoleculeFlag: Boolean) = apply {
+            centerTheMoleculeCoordinatesFlag = centerTheMoleculeFlag
+        }
+
+        /**
+         * for now a mandatory definition of the stream to use.
+         * Later there may be other input modalities TBD
+         */
+        fun loadPdbFromStream(theStreamToUse: InputStream) = apply {
+            inputStream = theStreamToUse
+        }
+
+        /**
+         * The actual parser execution
+         */
+        fun parse() = apply {
+            if (!this::inputStream.isInitialized) {
+                throw KotlinNullPointerException()
+            }
+            if (!this::messageStrings.isInitialized) {
+                messageStrings = mutableListOf("")
+            }
+
+//        resetMoleculeMaxMin()
+//        mol.clearLists()
+            loadPdbFromInputStream(inputStream)
+            /*
+             * Todo: ?? addHelixSecondaryInformation - update for HELIX records
+             */
+            if (doBondProcessing) {
+                mapBonds()
+                buildPdbChainLists()
+                addHelixSecondaryInformation()
+                addSheetSecondaryInformation()
+                connectResidues()
+            }
+
+            averageX /= mol.atomNumberList.size
+            averageY /= mol.atomNumberList.size
+            averageZ /= mol.atomNumberList.size
+            mol.averagePosition.x = averageX
+            mol.averagePosition.y = averageY
+            mol.averagePosition.z = averageZ
+            
+            if (centerTheMoleculeCoordinatesFlag) centerMolecule()
+        }
+
+        /**
+         * read the PDB file line by line, parsing each line.  The prefix
+         * determines the parsing action.
+         *
+         * TODO: handle multiple models.  Currently the parsing stops at the end of the first model.
+         */
+        private fun loadPdbFromInputStream(inputStream: InputStream?) {
+            val reader: BufferedReader
+            var line: String?
+
+            var skipToEnd = false
+            try {
+                requireNotNull(inputStream)
+                reader = BufferedReader(InputStreamReader(inputStream))
+
+                line = reader.readLine()
+                while (line != null) {
+                    if (line.length < 6) {
+                        line = reader.readLine()
+                        continue
+                    }
+                    if (line.substring(0, 6) == "CONECT") {
+                        parseConect(line)
+                    } else if (skipToEnd) { // hit an ENDMDL, skipping to CONECTs
+                        line = reader.readLine()
+                        continue
+                    } else if (line.substring(0, 4) == "ATOM") {
+                        parseAtom(line, PdbAtom.AtomType.IS_ATOM)
+                    } else if (line.substring(0, 6) == "HETATM") {
+                        parseAtom(line, PdbAtom.AtomType.IS_HETATM)
+                    } else if (line.substring(0, 3) == "TER") {
+                        parseTerRecord(line)
+                    } else if (line.substring(0, 5) == "HELIX") {
+                        parseHelix(line)
+                    } else if (line.substring(0, 5) == "SHEET") {
+                        parseBetaSheet(line)
+                    } else if (line.substring(0, 6) == "ENDMDL") {  // only do the 1st model
+                        // TODO: optionally parse additional models if flag is set
+                        messageStrings.add(
+                                String.format(
+                                        "%sparsing: MODELs are used.  Only 1st MODEL is parsed.",
+                                        messageMolName()))
+                        skipToEnd = true
+                    }
+                    line = reader.readLine()
+                }
+                reader.close()
+                inputStream.close()
+            } catch (e: IOException) {
+                messageStrings.add("IO error reading the stream")
+                return
+            }
+        }
+
+        /**
+         * mapBonds
+         * Look for the initial atom in a residue.  Then call matchBonds
+         * to iterate over the residue to map all the bonds within the residue
+         *
+         * Added "residue_insertion_code" to handle "duplicated" residue numbers
+         * from the insertion of residues.
+         */
+        private fun mapBonds() {
+            val resnameToBonds = bondinfo.kotmolBondLookup
+
+            var residueName: String
+            var anAtom: PdbAtom?
+            var residueSequenceNumber: Int
+            var residueInsertionCode: Char
+            var warnOnUnknownResidue = false
+
+            var i = 0
+            while (i < mol.atomNumberList.size) {
+                anAtom = mol.atomNumberToAtomInfoHash[mol.atomNumberList[i]]
+                requireNotNull(anAtom)
+                if (anAtom.atomType == PdbAtom.AtomType.IS_HETATM
+                        || anAtom.atomType == PdbAtom.AtomType.IS_TER_RECORD) {
+                    i++
+                    continue
+                }
+                residueSequenceNumber = anAtom.residueSeqNumber
+                residueInsertionCode = anAtom.residueInsertionCode
+                residueName = anAtom.residueName.lowercase()
+
+                if (!resnameToBonds.containsKey(residueName)) {
+                    if (residueName == "unk") {
+                        if (!warnOnUnknownResidue) {
+                            messageStrings.add(String.format(
+                                    "matchBonds: UNK (unknown) residues present in PDB file"))
+                            warnOnUnknownResidue = true
+                        }
+                        i++
+                        continue
+                    }
+                    messageStrings.add(String.format(
+                            "matchBonds: no matching info for residue %s at atom %d",
+                            residueName,
+                            anAtom.atomNumber))
+                    i++
+                    continue
+                }
+                val bondMap = resnameToBonds[residueName]
+                requireNotNull(bondMap)
+                matchBonds(i, residueName, residueSequenceNumber, residueInsertionCode, bondMap)
+                i++
+                /*
+                 * now skip through the rest of the atoms in the residue until the next residue starts
+                 */
+                while (i < mol.atomNumberList.size) {
+                    val atomSerialNumber = mol.atomNumberList[i]
+                    anAtom = mol.atomNumberToAtomInfoHash[atomSerialNumber]
+                    requireNotNull(anAtom)
+                    if (anAtom.residueSeqNumber != residueSequenceNumber
+                            || anAtom.residueInsertionCode != residueInsertionCode
+                            || anAtom.residueName.lowercase() != residueName) {
+                        break
+                    }
+                    i++
+                    /*
+                    * stop skipping if we cross a TER record
+                    */
+                    if (mol.terRecordTest[atomSerialNumber+1] == true) {
+                        break
+                    }
+                }
+                if (i == mol.atomNumberToAtomInfoHash.size) {
+                    break
+                } else {
+                    i--
+                }
+                i++
+            }
+        }
+
+        /**
+         * matchBonds
+         * walk the residue to match each atom in the residue with a bonding
+         * atom in the residue.   Basically build the bond table for the residue.
+         * @param atomIndex   initial atom in the residue
+         * @param residueSequenceNumber    the current residue number
+         * @param residueInsertionCode     PDB code for inserted residues (repeated sequences)
+         * @param bondListOriginal         the bond list for the residue
+         */
+        // TODO: rework to search the array instead of look up values in the map
+        private fun matchBonds(
+                atomIndex: Int,
+                residueName: String,
+                residueSequenceNumber: Int,
+                residueInsertionCode: Char,
+                bondListOriginal: List<BondInfo.KotmolBondRecord>) {
+
+            // for each atom, pull a bond for the atom if any (might not be in list)
+            // then search for the bonding atom in the residue.   It should be there.
+
+            var currentAtom: PdbAtom?
+            var loopAtom: PdbAtom?
+            val bondList = ArrayList(bondListOriginal.map { it.copy() })
+
+            // val ca_atom = false
+
+            /*
+             * interate through the atoms in the residue.   quit if there is an inserted
+             *    residue (residue insertion code changes).
+             * for each atom, search the residue for a bond match based on the bond table
+             */
+            var i = atomIndex
+            var j = 0
+            while (true) {
+
+                if (i >= mol.atomNumberList.size) {
+                    break
+                }
+                var atomSerialNumber = mol.atomNumberList[i]
+
+                currentAtom = mol.atomNumberToAtomInfoHash[atomSerialNumber]
+                if (currentAtom == null) {
+                    i++
+                    continue
+                }
+
+                // has the loop arrived at the next residue?
+                if (currentAtom.residueSeqNumber != residueSequenceNumber
+                        || currentAtom.residueInsertionCode != residueInsertionCode
+                        || currentAtom.residueName.lowercase() != residueName.lowercase()) {
+                    break
+                }
+
+                /*
+                 * keep scanning the rest of the residue until we run out
+                 * of bond candidates in the bond list
+                 */
+                while (true) {
+                    /*
+                     * scan the bondList for the currentAtom.   If there is a bond pair
+                     * that hasn't already been added to the bond list, then add it
+                     */
+                    val bondAtomName = findNextBond(currentAtom.atomName, bondList)
+                    if (bondAtomName == "") {
+                        break
+                    }
+                    /*
+                     * OK bondAtomName has the name of a atom in this residue type to which
+                     * currentAtom is bonded.   Now to find that atom in the atomList
+                     * for this residue
+                     *
+                     * Modified: scan starting at the *next* atom - don't rescan the previous
+                     * atoms.   That is because all previous bonds are now marked as used.
+                     */
+                    j = i + 1
+                    while (true) {
+                        if (j >= mol.atomNumberList.size) {
+                            break
+                        }
+                        atomSerialNumber = mol.atomNumberList[j]
+
+                        loopAtom = mol.atomNumberToAtomInfoHash[atomSerialNumber]
+                        if (loopAtom == null) {
+                            j++
+                            continue
+                        }
+                        /*
+                         * if the loop has reached the next residue, then quit
+                         */
+                        if (loopAtom.residueSeqNumber != residueSequenceNumber
+                                || loopAtom.residueInsertionCode.lowercaseChar() != residueInsertionCode.lowercaseChar()) {
+                            break
+                        }
+
+                        if (loopAtom.atomName == bondAtomName) {
+                            addBond(currentAtom, loopAtom)
+                            break
+                        }
+                        j++
+                        /*
+                         * has the loop hit a TER record?  Then exit the loop
+                         */
+                        if (mol.terRecordTest[atomSerialNumber+1] == true) {
+                             break
+                        }
+                    }
+                }
+
+                if (currentAtom.atomBondCount == 0) {
+                    mol.unbondedAtomCount++
+
+                    /*
+                     * if there is only one atom in the residue, then this is
+                     * likely a CA chain only model.   Don't complain about
+                     * missing bonds
+                     */
+                    if (j != i + 1) {
+                        messageStrings.add(String.format(
+                                "matchBonds: pdbName: %s no Bond Atom for atom %d in residue %s atomType %s",
+                                mol.molName, currentAtom.atomNumber, currentAtom.residueName, currentAtom.atomName))
+//                Timber.e("matchBonds file: " + mMol.name + " no CHARMM entry for atom " + currentAtom.atomNumber +
+//                        " residue " + currentAtom.residueName + " type " + currentAtom.atomName)
+                    }
+                }
+
+                atomSerialNumber = mol.atomNumberList[i]
+                if (mol.terRecordTest[atomSerialNumber+1] == true) {
+                    break
+                }
+                i++
+            }
+        }
+
+        /**
+         * findNextBond
+         * scan the copy of the Bond Records and return an unused bond partner if one exists.
+         * to the bond table
+         * @param atomName atom to match in the list
+         * @param bondList - list of atom to atom bonds for the current residue
+         */
+        private fun findNextBond(atomName: String, bondList: ArrayList<BondInfo.KotmolBondRecord>): String {
+            for (bond in bondList) {
+                if (bond.bondRecordCreated) {
+                    continue
+                }
+                if (atomName == bond.atom_1) {
+                    bond.bondRecordCreated = true
+                    return (bond.atom_2)
+                }
+                if (atomName == bond.atom_2) {
+                    bond.bondRecordCreated = true
+                    return (bond.atom_1)
+                }
+            }
+            // no bond
+            return ("")
+        }
+
+
+        /**
+         * addBond
+         * check for a pre-existing bond, and if none, add a bond from atom1 to atom2
+         * to the bond table
+         * @param atom1 from atom
+         * @param atom2 to atom
+         */
+        private fun addBond(atom1: PdbAtom, atom2: PdbAtom): Bond? {
+            if (atom1.atomBondCount > 0 &&
+                atom2.atomBondCount > 0) {
+
+//                if (doesDuplicateBondExist(atom2, atom1)) {
+//                    return null
+//                }
+
+                // new test - look up the bond in the hash map - if there is a non-null response
+                // then the bond is already in the map.
+                val theBondEncoded1 = atom1.atomNumber shl 16 or atom2.atomNumber
+                val theBondEncoded2 = atom2.atomNumber shl 16 or atom1.atomNumber
+                if (encodedBondMap[theBondEncoded1] != null) {
+                    return null
+                }
+                if (encodedBondMap[theBondEncoded2] != null) {
+                    return null
+                }
+
+            }
+            val bond = Bond(atom1.atomNumber, atom2.atomNumber)
+            mol.bondList.add(bond)
+
+            // add the bond to a HashMap for very fast lookup
+
+            val theBondEncoded = atom1.atomNumber shl 16 or atom2.atomNumber
+            encodedBondMap[theBondEncoded] = true
+
+            atom1.atomBondCount = atom1.atomBondCount + 1
+            atom2.atomBondCount = atom2.atomBondCount + 1
+            return(bond)
+        }
+
+        /*
+         * Walk the PDB Atom list and assemble lists of the chains
+         */
+        private fun buildPdbChainLists() {
+
+            var anAtom: PdbAtom?
+
+            var chainList: MutableList<ChainRenderingDescriptor> = ArrayList()
+            var chain = ChainRenderingDescriptor()
+
+            // set base chain_id to the chain_id of the first atom
+            anAtom = mol.atomNumberToAtomInfoHash[mol.atomNumberList[0]]
+            if (anAtom == null) {
+                messageStrings.add("buildPdbChainLists: error - first atom is null!")
+                return
+            }
+            var currentChainIdChar = anAtom.chainId
+            var residueSequenceNumber = anAtom.residueSeqNumber
+
+            for (i in 0 until mol.atomNumberList.size) {
+                anAtom = mol.atomNumberToAtomInfoHash[mol.atomNumberList[i]]
+                if (anAtom == null) {
+                    messageStrings.add(String.format(
+                            "buildPdbChainLists: error - got null for %d", mol.atomNumberList[i]))
+                    continue
+                }
+                if (anAtom.atomType == PdbAtom.AtomType.IS_TER_RECORD) {
+                    continue
+                }
+                /*
+                 * if this is a new residue sequence,
+                 * then add the previous residue info to the list
+                 */
+                if (residueSequenceNumber != anAtom.residueSeqNumber) {
+                    residueSequenceNumber = anAtom.residueSeqNumber
+                    if (chain.backboneAtom != null) {
+                        chainList.add(chain)
+                        if (chain.guideAtom == null) {
+                            /*
+                             * don't repeat this message
+                             */
+                            if (!mol.guideAtomMissing) {
+                                messageStrings.add(
+                                        String.format(
+                                        "%sbuildPdbChainLists: no guide atom in residue at atom %d",
+                                                messageMolName(),
+                                                anAtom.atomNumber))
+                                mol.guideAtomMissing = true
+                            }
+                            chain.guideAtom = chain.backboneAtom // HACK
+                        }
+                        chain = ChainRenderingDescriptor()
+                    }
+                }
+
+                /*
+                 * if this is a new chain, then add the old list to the
+                 * molecule list of lists.
+                 */
+                if (currentChainIdChar != anAtom.chainId) {
+                    currentChainIdChar = anAtom.chainId
+                    if (chainList.size > 2) {
+                        mol.listofChainDescriptorLists.add(chainList)
+                        mol.ribbonNodeCount = mol.ribbonNodeCount + chainList.size
+                        chainList = ArrayList()
+                    } else {
+                        chainList.clear()
+                    }
+                }
+
+                // skip water for now
+                if (anAtom.residueName == "HOH") {
+                    continue
+                }
+
+                // don't build chains of HETATMs, rely on CONECT records for bonds
+                if (anAtom.atomType == PdbAtom.AtomType.IS_HETATM) {
+                    continue
+                }
+
+                // basic linear chain of amino acid residues (polypeptide)
+                when (anAtom.atomName) {
+                    "CA" -> chain.backboneAtom = anAtom
+                    "O" -> chain.guideAtom = anAtom
+                    "N" -> chain.startAtom = anAtom
+                    "C" -> chain.endAtom = anAtom
+                }
+
+                // strand of nucleic acid
+                when (anAtom.atomName) {
+                    "C5'" -> {
+                        chain.backboneAtom = anAtom
+                        chain.secondaryStructureType = ChainRenderingDescriptor.SecondaryStructureType.NUCLEIC
+                    }
+                    "C1'" -> chain.guideAtom = anAtom
+                    "O5'" -> chain.startAtom = anAtom
+                    "O3'" -> chain.endAtom = anAtom
+                    "C3'" -> chain.nucleicEndAtom = anAtom
+                }
+
+                // extract the guide atoms for rendering the nucleic ladder
+                if (anAtom.residueName == "DC" || anAtom.residueName == "DT"
+                        || anAtom.residueName == "C" || anAtom.residueName == "T"
+                        || anAtom.residueName == "U") {
+                    chain.nucleicType = ChainRenderingDescriptor.NucleicType.PURINE
+                    when (anAtom.atomName) {
+                        "N1" -> {
+                            chain.nucleicCornerAtom = anAtom
+                            anAtom.atomType = PdbAtom.AtomType.IS_NUCLEIC
+                        }
+                        "C2" -> chain.nucleicGuideAtom = anAtom
+                        "C6" -> chain.nucleicPlanarAtom = anAtom
+                    }
+                } else if (anAtom.residueName == "DA" || anAtom.residueName == "DG"
+                        || anAtom.residueName == "A" || anAtom.residueName == "G"
+                        // 2n0l  see: en.wikipedia.org/wiki/8-Oxoguanine
+                        || anAtom.residueName == "8OG") {
+                    chain.nucleicType = ChainRenderingDescriptor.NucleicType.PYRIMIDINE
+                    when (anAtom.atomName) {
+                        "N9" -> {
+                            chain.nucleicCornerAtom = anAtom
+                            anAtom.atomType = PdbAtom.AtomType.IS_NUCLEIC
+                        }
+                        "C4" -> chain.nucleicGuideAtom = anAtom
+                        "N7" -> chain.nucleicPlanarAtom = anAtom
+                    }
+                }
+
+                // mark which atoms should be displayed for ribbon mode
+                if (anAtom.atomName == "C1'"
+                        || anAtom.atomName == "C2'"
+                        || anAtom.atomName == "C3'"
+                        || anAtom.atomName == "C4'"
+                        || anAtom.atomName == "O4'") {
+                    anAtom.atomType = PdbAtom.AtomType.IS_NUCLEIC
+                }/* || an_atom.atom_name.equals("N1") */
+            }
+            /*
+             * finish up
+             */
+            if (chainList.size > 2) {
+                if (chain.backboneAtom != null) {
+                    chainList.add(chain)
+                }
+                mol.listofChainDescriptorLists.add(chainList)
+                mol.ribbonNodeCount = mol.ribbonNodeCount + chainList.size
+            } else {
+                chainList.clear()
+            }
+        }
+
+        /*
+         * walk the list of helix records -
+         *    search for the records in the ChainRenderingDescriptor list.
+         *    update the secondary type for helix records.
+         *    this will make it pretty easy to switch modes later when
+         *       rendering the ribbon.
+         */
+        private fun addHelixSecondaryInformation() {
+            var i: Int
+            var j = 0
+
+            val alphaHelixList = mol.helixList
+            if (alphaHelixList.size == 0) {
+                return
+            }
+
+            var initialResidueNumber: Int
+            var initialChainIdChar: Char
+            var terminalResidueNumber: Int
+            var terminalChainIdChar: Char
+            var list: List<*>? = null
+
+            for (list_count in alphaHelixList.indices) {
+                val pdbHelix = alphaHelixList[list_count]
+
+                initialResidueNumber = pdbHelix.initialResidueNumber
+                initialChainIdChar = pdbHelix.initialChainIdChar
+                terminalResidueNumber = pdbHelix.terminalResidueNumber
+                terminalChainIdChar = pdbHelix.terminalChainIdChar
+
+                val listOfLists = mol.listofChainDescriptorLists
+                var found = false
+                i = 0
+                while (i < listOfLists.size) {
+                    list = listOfLists[i]
+                    j = 0
+                    while (j < list.size) {
+                        val item = list[j]
+                        if (item.backboneAtom!!.chainId == initialChainIdChar && item.backboneAtom!!.residueSeqNumber == initialResidueNumber) {
+                            item.secondaryStructureType = ChainRenderingDescriptor.SecondaryStructureType.ALPHA_HELIX
+                            found = true
+                            break
+                        }
+                        j++
+                    }
+                    if (found) {
+                        break
+                    }
+                    i++
+                }
+                if (!found) {
+                    messageStrings.add(String.format(
+                            "HELIX residue not found - number %d chain char %c",
+                            initialResidueNumber, initialChainIdChar))
+//                Timber.e(mPdbFileName +
+//                        ": HELIX residue not found - number " + initialResidueNumber +
+//                        " chain char: " + initialChainIdChar)
+                    continue
+                }
+                /*
+                 * Walk the "list" of
+                 * ChainRenderingDescriptors and mark the records as HELIX.
+                 * At the last record flip the boolean to flag it.
+                 */
+                var nextItem: ChainRenderingDescriptor? = null
+                while (j < list!!.size - 1) {
+                    nextItem = list[j + 1] as ChainRenderingDescriptor
+                    nextItem.secondaryStructureType = ChainRenderingDescriptor.SecondaryStructureType.ALPHA_HELIX
+                    if (nextItem.backboneAtom!!.chainId == terminalChainIdChar && nextItem.backboneAtom!!.residueSeqNumber == terminalResidueNumber) {
+                        nextItem.endOfSecondaryStructure = true
+                        break
+                    }
+                    j++
+                }
+                /*
+                 * shouldn't happen but error check to make sure we found the terminating residue
+                 */
+                if (nextItem != null && !nextItem.endOfSecondaryStructure) {
+
+                    messageStrings.add(String.format(
+                            "terminating HELIX residue not found- number %d chain char %c",
+                            terminalResidueNumber,
+                            terminalChainIdChar))
+//                Timber.e(mPdbFileName +
+//                        ": terminating HELIX residue not found- number " + terminalResidueNumber +
+//                        " chain char: " + terminalChainIdChar)
+                    nextItem.endOfSecondaryStructure = true
+                }
+            }
+        }
+
+
+        /*
+         * walk the list of helix records -
+         *    search for the records in the ChainRenderingDescriptor list.
+         *    update the secondary type for helix records.
+         *    this will make it pretty easy to switch modes later when
+         *       rendering the ribbon.
+        */
+        private fun addSheetSecondaryInformation() {
+            var i: Int
+            var j: Int
+
+            val betaSheetList = mol.pdbSheetList
+            if (betaSheetList.size == 0) {
+                return
+            }
+
+            var initialResidueNumber: Int
+            var initialChainIdChar: Char
+            var terminalResidueNumber: Int
+            var terminalChainIdChar: Char
+            var list: List<*>? = null
+
+            for (list_count in betaSheetList.indices) {
+                val pdbSheet = betaSheetList[list_count]
+
+                initialResidueNumber = pdbSheet.initialResidueNumber
+                initialChainIdChar = pdbSheet.initialChainIdChar
+                terminalResidueNumber = pdbSheet.terminalResidueNumber
+                terminalChainIdChar = pdbSheet.terminalChainIdChar
+
+                val listOfLists = mol.listofChainDescriptorLists
+                var found = false
+                i = 0
+                while (i < listOfLists.size) {
+                    list = listOfLists[i]
+                    j = 0
+                    while (j < list.size) {
+                        val item = list[j]
+                        if (item.backboneAtom!!.chainId == initialChainIdChar && item.backboneAtom!!.residueSeqNumber == initialResidueNumber) {
+                            item.secondaryStructureType = ChainRenderingDescriptor.SecondaryStructureType.BETA_SHEET
+                            found = true
+                            break
+                        }
+                        j++
+                    }
+                    if (found) {
+                        break
+                    }
+                    i++
+                }
+                if (!found) {
+                    messageStrings.add(String.format(
+                            "SHEET residue not found - number %d chain char: %c",
+                            initialResidueNumber, initialChainIdChar))
+//                Timber.e("%s: SHEET residue not found - number %d chain char: %c",
+//                        mPdbFileName, initialResidueNumber, initialChainIdChar)
+                    continue
+                }
+                /*
+                 * Walk the "list" of
+                 * ChainRenderingDescriptors and mark the records as BETA_SHEET.
+                 * At the last record flip the boolean to flag it.
+                 */
+                var nextItem: ChainRenderingDescriptor? = null
+                j = 0
+                while (j < list!!.size - 1) {
+                    nextItem = list[j + 1] as ChainRenderingDescriptor
+                    nextItem.secondaryStructureType = ChainRenderingDescriptor.SecondaryStructureType.BETA_SHEET
+                    if (nextItem.backboneAtom!!.chainId == terminalChainIdChar && nextItem.backboneAtom!!.residueSeqNumber == terminalResidueNumber) {
+                        nextItem.endOfSecondaryStructure = true
+                        break
+                    }
+                    j++
+                }
+                /*
+                 * shouldn't happen but error check to make sure we found the terminating residue
+                 */
+                if (nextItem != null && !nextItem.endOfSecondaryStructure) {
+                    messageStrings.add(String.format(
+                            "SHEET terminating residue not found - number %d chain char: %c",
+                            initialResidueNumber, initialChainIdChar))
+//                Timber.e("%s: SHEET residue not found - number %d chain char: %c",
+//                        mPdbFileName, initialResidueNumber, initialChainIdChar)
+                    nextItem.endOfSecondaryStructure = true
+                }
+            }
+        }
+
+
+        /*
+         * scan the atom list looking for the C3-prime atom
+         *   with the same chain_id.   Use this atom for
+         *   the spline anchor.  Helper for formHelices().
+         */
+
+        private fun findSplineAnchor(
+                sequence_id: Char,
+                chain_id: Int,
+                helix_list: MutableList<Helix>): Boolean {
+
+            var anAtom: PdbAtom?
+
+            for (i in 0 until mol.atomNumberList.size) {
+                anAtom = mol.atomNumberToAtomInfoHash[mol.atomNumberList[i]]
+                if (anAtom == null) {
+                    messageStrings.add(String.format(
+                            "findSplineAnchor: error - got null for %d", mol.atomNumberList[i]))
+                    continue
+                }
+                if (anAtom.chainId == sequence_id) {
+                    if (anAtom.atomName != "C3'") {
+                        continue
+                    }
+                    if (anAtom.chainId.toInt() != chain_id) {
+                        continue
+                    }
+                    val helix = Helix()
+                    helix.chainId = sequence_id
+                    helix.atom = anAtom
+                    helix_list.add(helix)
+                    return true
+                }
+            }
+            return false
+        }
+
+        /**
+         * adjust the XYZ of each atom
+         * to shift the molecule around (0,0,0)
+         *
+         * Also track the max vector out from the average (shifted) center.
+         */
+        private fun centerMolecule() {
+
+            var maxVector = KotmolVector3()
+            var maxVectorMagnitude = 0.0f
+
+            var anAtom: PdbAtom?
+            for (i in 0 until mol.atomNumberList.size) {
+                anAtom = mol.atomNumberToAtomInfoHash[mol.atomNumberList[i]]
+                if (anAtom == null) {
+                    messageStrings.add(String.format(
+                            "centerMolecules: error - got null for %d", mol.atomNumberList[i]))
+                    continue
+                }
+                if (anAtom.atomType == PdbAtom.AtomType.IS_TER_RECORD) {
+                    continue
+                }
+                anAtom.atomPosition.x = anAtom.atomPosition.x - averageX
+                anAtom.atomPosition.y = anAtom.atomPosition.y - averageY
+                anAtom.atomPosition.z = anAtom.atomPosition.z - averageZ
+
+                // track the maximum magnitude of the atom positions away
+                // from the average position (outermost atom)
+                val vector = kotlin.math.sqrt(
+                       anAtom.atomPosition.x * anAtom.atomPosition.x +
+                       anAtom.atomPosition.y * anAtom.atomPosition.y +
+                       anAtom.atomPosition.z * anAtom.atomPosition.z)
+                if (vector > maxVectorMagnitude) {
+                    maxVector = KotmolVector3(
+                            anAtom.atomPosition.x,
+                            anAtom.atomPosition.y,
+                            anAtom.atomPosition.z)
+                    maxVectorMagnitude = vector
+                }
+            }
+
+            mol.maxPostCenteringVectorMagnitude  = maxVectorMagnitude
+            mol.maxPostCenteringCoordinate = maxVector
+
+        }
+
+        /**
+         * ParseAtom
+         */
+        private fun parseAtom(lineIn: String, atom_type_flag: PdbAtom.AtomType) {
+            var line = lineIn
+
+            val vx: Float
+            val vy: Float
+            val vz: Float
+            var avex = 0.0
+            var avey = 0.0
+            var avez = 0.0
+            val atom = PdbAtom()
+            try {
+
+                // TODO: figure out why the reader sometimes reads short of full line (line 233 in 1ana.pdb)
+                if (line.length < 78) {
+                    messageStrings.add(
+                            String.format(
+                                    "%sparsing: ATOM line is short (%d characters): %s",
+                                    messageMolName(),
+                                    line.length,
+                                    line))
+                    line = "$line                                                                          "
+                }
+                atom.atomType = atom_type_flag
+
+                atom.atomNumber = parseInteger(line.substring(7 - 1, 11).trim { it <= ' ' })
+                atom.atomName = line.substring(13 - 1, 16).trim { it <= ' ' }
+                atom.residueName = line.substring(18 - 1, 20).trim { it <= ' ' }
+                atom.chainId = line[22 - 1]
+                atom.elementSymbol = line.substring(77 - 1, 78).trim { it <= ' ' }
+
+                atom.residueSeqNumber = parseInteger(line.substring(23 - 1, 26).trim { it <= ' ' })
+                atom.residueInsertionCode = line[27 - 1]
+                vx = parseFloat(line.substring(31 - 1, 38).trim { it <= ' ' })
+                vy = parseFloat(line.substring(39 - 1, 46).trim { it <= ' ' })
+                vz = parseFloat(line.substring(47 - 1, 54).trim { it <= ' ' })
+
+                // don't include HETATM in average calculation
+                //if (atom_type_flag == PdbAtom.AtomType.IS_ATOM) {
+                    averageX += vx
+                    averageY += vy
+                    averageZ += vz
+                //}
+
+                atom.atomPosition = KotmolVector3(vx, vy, vz)
+
+                // Decision: throw out O5T, and O3T atoms - no bond info - see README.md
+
+                if (atom.atomName == "O5T" || atom.atomName == "O3T") {
+                    messageStrings.add(String.format(
+                            "parseAtom: pdbName: %s atom is one of O5T, O3T, skipping", mol.molName))
+//                Timber.d("%s: atom is one of OXT, O5T, O3T, skipping", mMol.name)
+                    return
+                }
+
+                /*
+                 * check for "Alternate location indicator" at position 17
+                 *    if present it is typically "A or B or ..."
+                 * take only the A case
+                 */
+                if (line[17 - 1] != ' ') {
+                    if (line[17 - 1] != 'A') {
+                        if (!mol.hasAlternateLocations) {
+                            messageStrings.add(String.format(
+                                    "parseAtom: pdbName: %s: Alternate location indicator is %c, skippping",
+                                    mol.molName, line[17 - 1]))
+                            mol.hasAlternateLocations = true
+                        }
+                        return
+                    }
+                }
+
+                mol.atomNumberToAtomInfoHash[atom.atomNumber] = atom
+                mol.atomNumberList.add(atom.atomNumber)
+                mol.maxAtomNumber = if (mol.maxAtomNumber < atom.atomNumber)
+                    atom.atomNumber
+                else
+                    mol.maxAtomNumber
+
+            } catch (e: Exception) {
+                messageStrings.add(String.format(
+                        "parseAtom exception on line %s", line))
+//            Timber.e("parseAtom exception on line %s", line)
+            }
+
+        }
+
+        /**
+         * ParseBetaSheet
+         */
+        private fun parseBetaSheet(lineIn: String) {
+            var line = lineIn
+            val betaSheet = PdbBetaSheet()
+
+            // pad out - in case of short "sheeting" (LOL)
+            line = "$line                                                   "
+
+            betaSheet.strandNumber = parseInteger(line.substring(8 - 1, 10).trim { it <= ' ' })
+            betaSheet.numStrandsInSheet = parseInteger(line.substring(15 - 1, 16).trim { it <= ' ' })
+            betaSheet.initialResidueNumber = parseInteger(line.substring(23 - 1, 26).trim { it <= ' ' })
+            betaSheet.terminalResidueNumber = parseInteger(line.substring(34 - 1, 37).trim { it <= ' ' })
+            betaSheet.parallelSenseCode = parseInteger(line.substring(39 - 1, 40).trim { it <= ' ' })
+            betaSheet.registrationCurrentSeqNumber = parseInteger(line.substring(51 - 1, 54).trim { it <= ' ' })
+            betaSheet.registrationPreviousSeqNumber = parseInteger(line.substring(66 - 1, 69).trim { it <= ' ' })
+
+            betaSheet.sheetIdentification = line.substring(12 - 1, 14).trim { it <= ' ' }
+            betaSheet.initialResidueName = line.substring(18 - 1, 20).trim { it <= ' ' }
+            betaSheet.terminalResidueName = line.substring(29 - 1, 31).trim { it <= ' ' }
+            betaSheet.registrationCurrentAtomName = line.substring(42 - 1, 45).trim { it <= ' ' }
+            betaSheet.registrationCurrentResidueName = line.substring(46 - 1, 48).trim { it <= ' ' }
+            betaSheet.registrationPreviousAtomName = line.substring(57 - 1, 60).trim { it <= ' ' }
+            betaSheet.registrationPreviousResidueName = line.substring(61 - 1, 63).trim { it <= ' ' }
+
+            betaSheet.initialChainIdChar = line[22 - 1]
+            betaSheet.initialInsertionCodeChar = line[27 - 1]
+            betaSheet.terminalChainIdChar = line[33 - 1]
+            betaSheet.terminalInsertionCodeChar = line[38 - 1]
+            betaSheet.registrationCurrentChainChar = line[50 - 1]
+            betaSheet.registrationCurrentInsertionCodeChar = line[55 - 1]
+            betaSheet.registrationPreviousChainChar = line[65 - 1]
+            betaSheet.registrationPreviousInsertionCodeChar = line[70 - 1]
+
+            mol.pdbSheetList.add(betaSheet)
+        }
+
+        /*
+         * this is inserted to keep the mapping of atom_umber to array entry working
+         */
+        @Suppress("UseExpressionBody")
+        private fun parseTerRecord(lineIn: String) {
+            val atom = PdbAtom()
+            var line = lineIn
+
+            try {
+
+                // TODO: figure out why the reader sometimes reads short of full line (line 233 in 1ana.pdb)
+                if (line.length < 78) {
+                    messageStrings.add(
+                            String.format(
+                                    "%sparsing: TER line is short: %s",
+                                    messageMolName(),
+                            line))
+                    line = "$line                                                                          "
+                }
+
+
+                val terNumber = parseInteger(line.substring(7 - 1, 11).trim { it <= ' ' })
+                mol.terRecordTest[terNumber] = true
+
+                atom.atomType = PdbAtom.AtomType.IS_TER_RECORD
+                atom.atomName = "TER_RECORD"
+                atom.atomNumber = terNumber
+                atom.elementSymbol = ""
+
+                mol.atomNumberToAtomInfoHash[atom.atomNumber] = atom
+                mol.atomNumberList.add(atom.atomNumber)
+                mol.maxAtomNumber = if (mol.maxAtomNumber < atom.atomNumber)
+                    atom.atomNumber
+                else
+                    mol.maxAtomNumber
+
+            } catch (e: Exception) {
+                messageStrings.add(String.format(
+                        "parseAtom exception on line %s", line))
+//            Timber.e("parseAtom exception on line %s", line)
+            }
+
+        }
+
+        /**
+         * ParseHelix
+         */
+        private fun parseHelix(line: String) {
+
+            val helix = PdbHelix()
+
+            helix.serialNumber = parseInteger(line.substring(8 - 1, 10).trim { it <= ' ' })
+            helix.helixId = line.substring(12 - 1, 14).trim { it <= ' ' }
+
+            helix.initialResidueName = line.substring(16 - 1, 18).trim { it <= ' ' }
+            helix.initialChainIdChar = line[20 - 1]
+            helix.initialResidueNumber = parseInteger(line.substring(22 - 1, 25).trim { it <= ' ' })
+            helix.initialInsertionCode = line[26 - 1]
+
+            helix.terminalResidueName = line.substring(28 - 1, 30).trim { it <= ' ' }
+            helix.terminalChainIdChar = line[32 - 1]
+            helix.terminalResidueNumber = parseInteger(line.substring(34 - 1, 37).trim { it <= ' ' })
+            helix.terminalInsertionCode = line[38 - 1]
+
+            helix.helixClass = parseInteger(line.substring(39 - 1, 40).trim { it <= ' ' })
+            helix.helixComment = line.substring(41 - 1, 70).trim { it <= ' ' }
+
+            helix.helixLength = parseInteger(line.substring(72 - 1, 76).trim { it <= ' ' })
+
+            mol.helixList.add(helix)
+        }
+
+        /**
+         * parse CONECT records
+         */
+        private fun parseConect(line: String) {
+            val maxAtomNumber = mol.maxAtomNumber + 1
+            var connectedAtomId: Int
+            var idSubstring: String
+
+
+            val baseAtomId: Int
+            try {
+                baseAtomId = parseInteger(line.substring(7 - 1, 11).trim { it <= ' ' })
+
+                if (baseAtomId == 0) return
+                if (baseAtomId >= maxAtomNumber) return
+
+                connectedAtomId = parseInteger(line.substring(12 - 1, 16).trim { it <= ' ' })
+                if (connectedAtomId == 0) return
+                if (connectedAtomId < maxAtomNumber) {
+                    validateBond(baseAtomId, connectedAtomId)
+                }
+
+                if (line.length < 21) return
+                idSubstring = line.substring(17 - 1, 21).trim { it <= ' ' }
+                if (idSubstring.isEmpty()) return
+                connectedAtomId = parseInteger(idSubstring)
+                if (connectedAtomId == 0) return
+                if (connectedAtomId < maxAtomNumber) {
+                    validateBond(baseAtomId, connectedAtomId)
+                }
+
+                if (line.length < 26) return
+                idSubstring = line.substring(22 - 1, 26).trim { it <= ' ' }
+                if (idSubstring.isEmpty()) return
+                connectedAtomId = parseInteger(idSubstring)
+                if (connectedAtomId == 0) return
+                if (connectedAtomId < maxAtomNumber) {
+                    validateBond(baseAtomId, connectedAtomId)
+                }
+
+                if (line.length < 31) return
+                idSubstring = line.substring(27 - 1, 31).trim { it <= ' ' }
+                if (idSubstring.isEmpty()) return
+                connectedAtomId = parseInteger(idSubstring)
+                if (connectedAtomId == 0) return
+                if (connectedAtomId < maxAtomNumber) {
+                    validateBond(baseAtomId, connectedAtomId)
+                }
+
+            } catch (e: Exception) {
+                messageStrings.add(String.format("parse error on line: %s", line))
+//            Timber.e("parse error on line: %s", line)
+            }
+
+        }
+
+        /**
+         * doesDuplicateBondExist
+         * check for an existing bond between
+         * @param atom1
+         * @param atom2
+         * @return   true if there is an bond between already in the bond list
+         */
+        private fun doesDuplicateBondExist(atom1: PdbAtom, atom2: PdbAtom): Boolean {
+
+            val fromAtomNumber = atom1.atomNumber
+            val toAtomNumber = atom2.atomNumber
+            var atom1Number: Int
+            var atom2Number: Int
+
+            for (i in 0 until mol.bondList.size) {
+                atom1Number = mol.bondList[i].atomNumber1
+                atom2Number = mol.bondList[i].atomNumber2
+
+                if (fromAtomNumber == atom1Number
+                        && toAtomNumber == atom2Number) {
+                    return true
+                }
+                if (fromAtomNumber == atom2Number
+                        && toAtomNumber == atom1Number) {
+                    return true
+                }
+            }
+            return false
+        }
+
+        /**
+         * validateBond
+         *    treat CONECT records with some suspicion.   Check atom distances
+         *    before adding to the Bond table for the Molecule()
+         */
+        private fun validateBond(atom1: Int, atom2: Int) {
+
+            val a1 = mol.atomNumberToAtomInfoHash[atom1]
+            val a2 = mol.atomNumberToAtomInfoHash[atom2]
+
+            /*
+             * TODO: handle hydrogens.   For now skip over null pointers from missing hydros
+             */
+            if (a1 == null || a2 == null) {
+                return
+            }
+            val p1 = a1.atomPosition
+            val p2 = a2.atomPosition
+
+            val distanceSquared = (p1.x - p2.x) * (p1.x - p2.x) +
+                    (p1.y - p2.y) * (p1.y - p2.y) +
+                    (p1.z - p2.z) * (p1.z - p2.z)
+
+            if (distanceSquared > 20.0) {
+                val prettyPrint = String.format("%6.2f", kotlin.math.sqrt(distanceSquared))
+                messageStrings.add(String.format(
+                        "Bad CONECT between %d and %d distance is %d",
+                        atom1, atom2, prettyPrint))
+//            Timber.e("Bad CONECT between " + atom1
+//                    + " and " + atom2 + " distance is "
+//                    + prettyPrint)
+                return
+            }
+            val bond = addBond(a1, a2)
+            if (bond != null) { // only add the bond if it doesn't already exist
+                bond.type = BondType.CONECT
+            }
+
+        }
+
+        /**
+         * This is the last step in assembling the molecule information.
+         * This algorithm creates the bonds in the bond list that form the peptide chain.
+         * Procedure:
+         *    walk the list of atoms.
+         *    For each residue, attempt to connect the standard atoms in the polymeric chain.
+         *    Check the atom to atom spacing for error correction
+         *    TODO: test for TER records
+         */
+        private fun connectResidues() {
+            var totalDistance = 0f
+            var count = 0
+            var anAtom: PdbAtom?
+            var lastAtom: PdbAtom? = null
+            var lastResidueSequenceNumber = 0
+            for (i in 0 until mol.atomNumberList.size) {
+                anAtom = mol.atomNumberToAtomInfoHash[mol.atomNumberList[i]]
+                if (anAtom == null) {
+                    messageStrings.add(String.format("connectResidues: error - got null for %s", mol.atomNumberList[i]))
+                    continue
+                }
+                // rely on CONECT records for HETATM
+                if (anAtom.atomType == PdbAtom.AtomType.IS_HETATM) {
+                    continue
+                }
+                if (anAtom.atomName == "O3'" || anAtom.atomName == "C") {
+                    lastResidueSequenceNumber = anAtom.residueSeqNumber
+                    lastAtom = anAtom
+                } else if (anAtom.atomName == "P" || anAtom.atomName == "N") {
+                    if (anAtom.residueSeqNumber == lastResidueSequenceNumber + 1 && lastAtom != null) {
+                        // connect the atoms
+                        val dist = anAtom.atomPosition.distanceTo(lastAtom.atomPosition)
+                        if (dist < 2.0) {
+                            totalDistance += dist
+                            count++
+                            addBond(anAtom, lastAtom)
+                        } else {
+                            val prettyPrint = String.format("%6.2f", totalDistance / count.toFloat())
+                            messageStrings.add(String.format(
+                                    "connectResidues: excessive bond dist = %s from atom %s to %s",
+                                    prettyPrint,
+                                    lastAtom.atomNumber,
+                                    anAtom.atomNumber))
+                        }
+                        lastAtom = null
+                    }
+                }
+            }
+
+            /*if (count > 0) {
+                val prettyPrint = String.format("%6.2f", totalDistance / count.toFloat())
+                //Timber.i("connectResidues: ave connection distance = $prettyPrint")
+            }*/
+
+        }
+
+        private fun parseFloat(s: String): Float {
+            return try {
+                s.toFloat()
+            } catch (e: RuntimeException) {
+                0.toFloat()
+            }
+
+        }
+
+        private fun parseInteger(s: String): Int {
+            if (s.isEmpty()) {
+                return -1
+            }
+            return try {
+                Integer.parseInt(s)
+            } catch (e: RuntimeException) {
+//            Timber.e("Bad Integer : $s")
+                0
+            }
+        }
+
+        private fun messageMolName() : String {
+            if (mol.molName != "") {
+                return String.format("%s: ", mol.molName)
+            }
+            return("")
+        }
+    }
+}

--- a/pdbparser/src/main/java/com/kotmol/pdbParser/PdbAtom.kt
+++ b/pdbparser/src/main/java/com/kotmol/pdbParser/PdbAtom.kt
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2021 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress("unused")
+
+package com.kotmol.pdbParser
+
+import kotlin.math.sqrt
+
+class PdbAtom {
+    var atomNumber = 0
+    var atomType = AtomType.IS_NOT_A_TYPE
+    var atomName: String = ""
+    var residueName: String = ""
+    var chainId: Char = ' '
+    var residueSeqNumber = 0
+    var residueInsertionCode: Char = ' '
+    lateinit var atomPosition: KotmolVector3
+    var elementSymbol: String = ""
+    var atomBondCount = 0
+    var renderThisAtomAsSphere = false
+
+    enum class AtomType {
+        IS_ATOM,
+        IS_HETATM,
+        IS_NUCLEIC,
+        IS_TER_RECORD,
+        IS_NOT_A_TYPE
+    }
+}
+
+class Helix {
+    var chainId: Char = ' '
+    lateinit var atom: PdbAtom
+}
+
+class KotmolVector3(
+        var x: Float = 0.0f,
+        var y: Float = 0.0f,
+        var z: Float = 0.0f) {
+
+    fun distanceTo(q: KotmolVector3): Float {
+        val a = x - q.x
+        val b = y - q.y
+        val c = z - q.z
+        return sqrt(a * a + b * b + c * c)
+
+    }
+}
+
+
+/*
+ATOM line per PDB spec V33
+COLUMNS DATA TYPE FIELD DEFINITION
+-------------------------------------------------------------------------------------
+1 - 6 Record name "ATOM "
+7 - 11 Integer serial Atom serial number.
+13 - 16 Atom name Atom name.
+17 Character altLoc Alternate location indicator.
+18 - 20 Residue name resName Residue name.
+22 Character chainID Chain identifier.
+23 - 26 Integer resSeq Residue sequence number.
+27 AChar iCode Code for insertion of residues.
+31 - 38 Real(8.3) x Orthogonal coordinates for X in Angstroms.
+39 - 46 Real(8.3) y Orthogonal coordinates for Y in Angstroms.
+47 - 54 Real(8.3) z Orthogonal coordinates for Z in Angstroms.
+55 - 60 Real(6.2) occupancy Occupancy.
+61 - 66 Real(6.2) tempFactor Temperature factor.
+77 - 78 LString(2) element Element symbol, right-justified.
+79 - 80 LString(2) charge Charge on the atom.
+ */

--- a/pdbparser/src/main/java/com/kotmol/pdbParser/PdbBetaSheet.kt
+++ b/pdbparser/src/main/java/com/kotmol/pdbParser/PdbBetaSheet.kt
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2021 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+       "unused",
+      /*  "unused_variable",
+        "unused_parameter",
+        "unused_property",
+        "deprecation",
+        "ConstantConditionIf",
+        "LocalVariableName",
+        "PropertyName"*/)
+package com.kotmol.pdbParser
+
+class PdbBetaSheet {
+
+    var strandNumber: Int = 0
+    var sheetIdentification: String? = null
+    var numStrandsInSheet: Int = 0
+    var initialResidueName: String? = null
+    var initialChainIdChar: Char = ' '
+    var initialResidueNumber: Int = 0
+    var initialInsertionCodeChar: Char = ' '
+    var terminalResidueName: String? = null
+    var terminalChainIdChar: Char = ' '
+    var terminalResidueNumber: Int = 0
+    var terminalInsertionCodeChar: Char = ' '
+    var parallelSenseCode: Int = 0  // see SENSE_CODE, pulled from PDB data (don't enum covert!)
+
+    var registrationCurrentAtomName: String? = null
+    var registrationCurrentResidueName: String? = null
+    var registrationCurrentChainChar: Char = ' '
+    var registrationCurrentSeqNumber: Int = 0
+    var registrationCurrentInsertionCodeChar: Char = ' '
+
+    var registrationPreviousAtomName: String? = null
+    var registrationPreviousResidueName: String? = null
+    var registrationPreviousChainChar: Char = ' '
+    var registrationPreviousSeqNumber: Int = 0
+    var registrationPreviousInsertionCodeChar: Char = ' '
+
+    companion object {
+        const val SENSE_CODE_FIRST_STRAND = 0
+        const val SENSE_CODE_PARALLEL = 1
+        const val SENSE_CODE_ANIT_PARALLEL = -1
+    }
+}

--- a/pdbparser/src/main/java/com/kotmol/pdbParser/PdbHelix.kt
+++ b/pdbparser/src/main/java/com/kotmol/pdbParser/PdbHelix.kt
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+       /* "unused",
+        "unused_variable",
+        "unused_parameter",
+        "unused_property",
+        "deprecation",
+        "ConstantConditionIf",
+        "LocalVariableName",
+        "PropertyName"*/)
+package com.kotmol.pdbParser
+
+class PdbHelix {
+
+    var serialNumber: Int = 0
+    var helixId: String? = null
+
+    var initialResidueName: String? = null
+    var initialChainIdChar: Char = ' '
+    var initialResidueNumber: Int = 0
+    var initialInsertionCode: Char = ' '
+
+    var terminalResidueName: String? = null
+    var terminalChainIdChar: Char = ' '
+    var terminalResidueNumber: Int = 0
+    var terminalInsertionCode: Char = ' '
+
+    var helixClass: Int = 0
+    var helixComment: String? = null
+    var helixLength: Int = 0
+}
+
+/*
+ * Helices are classified as follows:
+CLASS NUMBER
+TYPE OF HELIX (COLUMNS 39 - 40)
+--------------------------------------------------------------
+Right-handed alpha (default) 1
+Right-handed omega 2
+Right-handed pi 3
+Right-handed gamma 4
+Right-handed 310 5
+Left-handed alpha 6
+Left-handed omega 7
+Left-handed gamma 8
+27 ribbon/helix 9
+Polyproline 10
+Relationships to
+
+Record Format
+COLUMNS DATA TYPE FIELD DEFINITION
+-----------------------------------------------------------------------------------
+1 - 6 Record name "HELIX "
+8 - 10 Integer serNum Serial number of the helix. This starts
+at 1 and increases incrementally.
+12 - 14 LString(3) helixID Helix identifier. In addition to a serial
+number, each helix is given an
+alphanumeric character helix identifier.
+16 - 18 Residue name initResName Name of the initial residue.
+20 Character initChainID Chain identifier for the chain containing
+this helix.
+22 - 25 Integer initSeqNum Sequence number of the initial residue.
+26 AChar initICode Insertion code of the initial residue.
+28 - 30 Residue name endResName Name of the terminal residue of the helix.
+32 Character endChainID Chain identifier for the chain containing
+this helix.
+34 - 37 Integer endSeqNum Sequence number of the terminal residue.
+38 AChar endICode Insertion code of the terminal residue.
+39 - 40 Integer helixClass Helix class (see below).
+41 - 70 String comment Comment about this helix.
+72 - 76 Integer length Length of this helix.
+ */

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/AFailedTest.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/AFailedTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2020 Bammellab / James Andreas
+ *  Copyright 2020 James Andreas
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
@@ -11,22 +11,16 @@
  *  limitations under the License
  */
 
-pluginManagement {
-    repositories {
-        google()
-        mavenCentral()
-        gradlePluginPortal()
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+internal class AFailedTest {
+    @Test @Disabled
+    @DisplayName("This Test Fails by design")
+    fun failTest() {
+        assert(false)
     }
 }
-
-dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
-rootProject.name = "MotmBrowser"
-
-include(":mollib", ":motmbrowser", ":standalone", ":captureimages", ":screensaver", ":pdbparser")

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest01.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest01.kt
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+/**
+ * Test processing of atom x/y/x coordinates
+ */
+internal class AtomCoordTest01 {
+
+    private lateinit var str00 : ByteArrayInputStream
+    val mol = Molecule()
+    val parse = ParserPdbFile(mol)
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        val anAtomZero = """
+ATOM      1  O5'  DC A   1      00.000  00.000  00.000  1.00 64.35           O
+        """.trimIndent()
+
+        str00 = anAtomZero.byteInputStream()
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str00.close()
+    }
+
+    @Test
+    @DisplayName( "test with a 000 coordinate atom")
+    fun testWithZeroCoordinateAtom() {
+        ParserPdbFile
+                .Builder(mol)
+                .loadPdbFromStream(str00)
+                .parse()
+
+        assertEquals(1, mol.maxAtomNumber)
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(1, atoms.size)
+
+        val firstAtom = atoms[1]
+        assertEquals("O5'", firstAtom?.atomName)
+        assertEquals("DC", firstAtom?.residueName)
+
+        val maxVector = mol.maxPostCenteringVectorMagnitude
+        assertEquals(maxVector, 0.0f, 0.01f)
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest02.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest02.kt
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+/**
+ * Test processing of atom x/y/x coordinates
+ */
+internal class AtomCoordTest02 {
+
+    lateinit var str00 : ByteArrayInputStream
+    val mol = Molecule()
+    val parse = ParserPdbFile(mol)
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        val anAtomZero = """
+ATOM      1  O5'  DC A   1     -05.000  00.000  00.000  1.00 64.35           O
+        """.trimIndent()
+
+        str00 = anAtomZero.byteInputStream()
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str00.close()
+    }
+
+    @Test
+    @DisplayName( "test with a -5 coordinate atom")
+    fun testWithZeroCoordinateAtom() {
+
+        var messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .loadPdbFromStream(str00)
+                .parse()
+
+        assertEquals(1, mol.maxAtomNumber)
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(1, atoms.size)
+
+        val firstAtom = atoms[1]
+        assertEquals("O5'", firstAtom?.atomName)
+
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest03.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest03.kt
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+/**
+ * Test processing of atom x/y/x coordinates
+ *
+ */
+internal class AtomCoordTest03 {
+
+    lateinit var str00 : ByteArrayInputStream
+    val mol = Molecule()
+    val parse = ParserPdbFile(mol)
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        val anAtomZero = """
+ATOM      1  O5'  DC A   1      00.000  10.000  00.000  1.00 64.35           O  
+ATOM      2  C5'  DC A   1      07.071 -07.071  00.000  1.00 44.69           C  
+ATOM      3  C4'  DC A   1     -07.071 -07.071  00.000  1.00 31.28           C 
+        """.trimIndent()
+
+        str00 = anAtomZero.byteInputStream()
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str00.close()
+    }
+
+    @Test
+    @DisplayName( "test with a 10, 10, 10 max coordinate atom")
+    fun testWithZeroCoordinateAtom() {
+
+        ParserPdbFile
+                .Builder(mol)
+                .loadPdbFromStream(str00)
+                .parse()
+
+        assertEquals(3, mol.maxAtomNumber)
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(3, atoms.size)
+
+        val maxVector = mol.maxPostCenteringVectorMagnitude
+        assertEquals(maxVector, 11.380666666666666f, 0.01f)
+    }
+}
+
+/*
+ATOM line per PDB spec V33
+COLUMNS DATA TYPE FIELD DEFINITION
+-------------------------------------------------------------------------------------
+1 - 6 Record name "ATOM "
+7 - 11 Integer serial Atom serial number.
+13 - 16 Atom name Atom name.
+17 Character altLoc Alternate location indicator.
+18 - 20 Residue name resName Residue name.
+22 Character chainID Chain identifier.
+23 - 26 Integer resSeq Residue sequence number.
+27 AChar iCode Code for insertion of residues.
+31 - 38 Real(8.3) x Orthogonal coordinates for X in Angstroms.
+39 - 46 Real(8.3) y Orthogonal coordinates for Y in Angstroms.
+47 - 54 Real(8.3) z Orthogonal coordinates for Z in Angstroms.
+55 - 60 Real(6.2) occupancy Occupancy.
+61 - 66 Real(6.2) tempFactor Temperature factor.
+77 - 78 LString(2) element Element symbol, right-justified.
+79 - 80 LString(2) charge Charge on the atom.
+ */

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest04.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest04.kt
@@ -1,0 +1,70 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+/**
+ * Test processing of atom x/y/x coordinates
+ *
+ * TODO: The max function needs work
+ *
+ */
+internal class AtomCoordTest04 {
+
+    lateinit var str00 : ByteArrayInputStream
+    val mol = Molecule()
+    val parse = ParserPdbFile(mol)
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        val anAtomZero = """
+ATOM      1  O5'  DC A   1      00.000  00.000  00.000  1.00 64.35           O  
+ATOM      2  C5'  DC A   1      00.000 -10.000  00.000  1.00 44.69           C  
+ATOM      3  C4'  DC A   1      00.000  00.000 -10.000  1.00 31.28           C 
+        """.trimIndent()
+
+        str00 = anAtomZero.byteInputStream()
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str00.close()
+    }
+
+    @Test
+    @DisplayName( "test with a 10, 10, 10 max coordinate atom")
+    fun testWithZeroCoordinateAtom() {
+
+        var messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .loadPdbFromStream(str00)
+                .parse()
+
+        assertEquals(3, mol.maxAtomNumber)
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(3, atoms.size)
+
+//        val maxCoord = mol.maxCoordinate
+//        assertEquals(maxCoord, 10.0)
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest05.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/AtomCoordTest05.kt
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+/**
+ * Test processing of atom x/y/x coordinates
+ *
+ * Checking the centering function
+ *
+ */
+internal class AtomCoordTest05 {
+
+    lateinit var str00 : ByteArrayInputStream
+    val mol = Molecule()
+    val parse = ParserPdbFile(mol)
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        val pdbWithOffset = """
+ATOM   1032  OE1 GLU A 134      31.189 -27.598  29.448  1.00 40.66           O  
+ATOM   1033  OE2 GLU A 134      32.782 -27.948  30.926  1.00 26.17           O
+
+HETATM 1368 CD    CD A 188      30.071 -29.333  31.283  0.33 19.30          CD  
+
+HETATM 1403  O   HOH A 358      30.428 -30.357  32.559  1.00 33.45           O  
+        """.trimIndent()
+
+        str00 = pdbWithOffset.byteInputStream()
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str00.close()
+    }
+
+    @Test
+    @DisplayName( "test centering with a short PDB")
+    fun testWithZeroCoordinateAtom() {
+
+        var messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .loadPdbFromStream(str00)
+                .parse()
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(4, atoms.size)
+        val aveP = mol.averagePosition
+        val maxP = mol.maxPostCenteringCoordinate
+        val maxV = mol.maxPostCenteringVectorMagnitude
+
+        assertEquals(30.0f, aveP.x, 3.0f)  // pre-centering ave X
+        assertEquals(0.0f, maxP.x, 1.0f)  // post-centering ave X
+        assertEquals(2.2f, maxV, 1.0f)  // post cenering max V
+
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/AtomInfoTest.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/AtomInfoTest.kt
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+internal class AtomInfoTest {
+
+    @Test
+    @DisplayName("touch test the atomInfo setup")
+    fun touchTestOfAtomInfo() {
+        val info = AtomInformationTable.atomTable
+
+        assertEquals("hydrogen", info[1 - 1].name)
+        assertEquals("H", info[1 - 1].symbol)
+        assertEquals(120, info[1 - 1].vanDerWaalsRadius)
+
+        assertEquals("carbon", info[6 - 1].name)
+        assertEquals("C", info[6 - 1].symbol)
+        assertEquals(170, info[6 - 1].vanDerWaalsRadius)
+
+        assertEquals("radium", info[88 - 1].name)
+        assertEquals("RA", info[88 - 1].symbol)
+        assertEquals(283, info[88 - 1].vanDerWaalsRadius)
+
+    }
+
+    @Test
+    @DisplayName("scan eleHash hash set for nulls and bad behavior")
+    fun scanHashSetForNulls() {
+        val hashSet = AtomInformationTable.atomSymboltoAtomNumNameColor
+
+        for (item in hashSet) {
+            val foo = item.key
+            val yup = hashSet.containsKey(foo)
+            assertTrue(yup)
+            val molNum = item.value
+            assertNotNull(molNum)
+            assertNotEquals(0, molNum)
+        }
+    }
+
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/BondGuanineTest01.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/BondGuanineTest01.kt
@@ -1,0 +1,133 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class BondGuanineTest01 {
+
+    /**
+     * 1BNA.pdb
+     *   Just the first Guanine entry is used in this test.
+     */
+    lateinit var str : ByteArrayInputStream
+    lateinit var aModelTest : String
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() {
+        val theModelString = """
+         1         2         3         4         5         6         7
+12345678901234567890123456789012345678901234567890123456789012345678901234567890"""
+        aModelTest = """
+ATOM     17  P    DG A   2      22.409  31.286  21.483  1.00 58.85           P  
+ATOM     18  OP1  DG A   2      23.536  32.157  21.851  1.00 57.82           O  
+ATOM     19  OP2  DG A   2      21.822  31.459  20.139  1.00 78.33           O  
+ATOM     20  O5'  DG A   2      22.840  29.751  21.498  1.00 40.36           O  
+ATOM     21  C5'  DG A   2      23.543  29.175  22.594  1.00 47.19           C  
+ATOM     22  C4'  DG A   2      23.494  27.709  22.279  1.00 47.81           C  
+ATOM     23  O4'  DG A   2      22.193  27.252  22.674  1.00 38.76           O  
+ATOM     24  C3'  DG A   2      23.693  27.325  20.807  1.00 28.58           C  
+ATOM     25  O3'  DG A   2      24.723  26.320  20.653  1.00 40.44           O  
+ATOM     26  C2'  DG A   2      22.273  26.885  20.416  1.00 21.14           C  
+ATOM     27  C1'  DG A   2      21.721  26.304  21.716  1.00 33.95           C  
+ATOM     28  N9   DG A   2      20.237  26.470  21.780  1.00 34.00           N  
+ATOM     29  C8   DG A   2      19.526  27.584  21.429  1.00 36.47           C  
+ATOM     30  N7   DG A   2      18.207  27.455  21.636  1.00 32.37           N  
+ATOM     31  C5   DG A   2      18.083  26.212  22.142  1.00 15.06           C  
+ATOM     32  C6   DG A   2      16.904  25.525  22.545  1.00 11.88           C  
+ATOM     33  O6   DG A   2      15.739  25.916  22.518  1.00 21.30           O  
+ATOM     34  N1   DG A   2      17.197  24.279  23.037  1.00 15.44           N  
+ATOM     35  C2   DG A   2      18.434  23.717  23.155  1.00  9.63           C  
+ATOM     36  N2   DG A   2      18.508  22.456  23.668  1.00 16.69           N  
+ATOM     37  N3   DG A   2      19.537  24.360  22.770  1.00 30.98           N  
+ATOM     38  C4   DG A   2      19.290  25.594  22.274  1.00 18.56           C  
+TER      39                                                                            
+END   
+        """.trimIndent()
+
+        str = aModelTest.byteInputStream()
+
+    }
+
+    /* Guanine:
+     * Parameters for all of these force fields may be downloaded from the Mackerell website for free.
+* http://mackerell.umaryland.edu/charmm_ff.shtml
+
+     *               O6
+     *               ||
+     *               C6
+     *              /  \
+     *          H1-N1   C5--N7\\
+     *             |    ||     C8-H8
+     *             C2   C4--N9/
+     *            / \\ /      \
+     *      H21-N2   N3        \
+     *          |               \
+     *         H22               \
+     *                            \
+     *        OP1    H5' H4'  O4'  \
+     *         |      |    \ /   \  \
+     *        -P-O5'-C5'---C4'    C1'
+     *         |      |     \     / \
+     *        OP2    H5''   C3'--C2' H1'
+     *                     / \   / \
+     *                  O3' H3' O2' H2'' + H2'
+     *                   |       |
+     *                          HO2'
+ 
+     */
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    /**
+     * make sure there are no bonds between the two residue - i.e. the TER record
+     * stops the bond processing even though the residue numbers are the same
+     */
+    @Test
+    @DisplayName( "test processing of Guanine bonds")
+    fun testTERrecordProcessing() {
+
+        val mol = Molecule()
+        val messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .setMoleculeName("1BNA")
+                .setMessageStrings(messages)
+                .loadPdbFromStream(str)
+                .parse()
+
+        //
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(23, atoms.size)
+
+        // checked bond list by examination - seems OK (relative to asciidraw above)
+        assertEquals(24, mol.bondList.size)
+
+        // check that the TER record is entered into the
+        // atom list as a TER_RECORD type.
+        val shouldBeTER = mol.atomNumberToAtomInfoHash[39]
+        assertNotNull(shouldBeTER)
+        assertEquals(PdbAtom.AtomType.IS_TER_RECORD, shouldBeTER!!.atomType)
+
+    }
+
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest02.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest02.kt
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class BondInfoTest02 {
+
+/*    @org.junit.jupiter.api.BeforeEach
+    fun setUp() {
+        println("Setup")
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        println("Teardown")
+    }*/
+
+    @Test
+    @DisplayName( "check that all entries exist")
+    fun testAllHashEntriesExist() {
+        val bondLookup = BondInfo()
+
+        val theList = listOf(
+        "ala",
+        "arg",
+        "asn",
+        "asp",
+        "asx",
+        "cys",
+        "glu",
+        "gln",
+        "glx",
+        "gly",
+        "his",
+        "ile",
+        "leu",
+        "lys",
+        "met",
+        "phe",
+        "pro",
+        "ser",
+        "thr",
+        "trp",
+        "tyr",
+        "val")
+        for (l in theList) {
+            val theBondInfo = bondLookup.kotmolBondLookup[l]
+            assertNotEquals(theBondInfo, null)
+            val theBondInfoResult = theBondInfo!![0]
+
+        }
+
+    }
+
+//    @Test
+//    @DisplayName( "this should fail")
+//    fun testThisFail() {
+//        assertEquals(1,2 )
+//    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest03.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest03.kt
@@ -1,0 +1,135 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+        "unused",
+        "unused_variable",
+        "unused_parameter",
+        "deprecation",
+        "UNUSED_ANONYMOUS_PARAMETER",
+        "UNUSED_EXPRESSION",
+        "MemberVisibilityCanBePrivate",
+        "FunctionWithLambdaExpressionBody",
+        "UnusedMainParameter", "JoinDeclarationAndAssignment",
+        "CanBePrimaryConstructorProperty", "RemoveEmptyClassBody",
+        "ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE", "UNUSED_VALUE",
+        "ConstantConditionIf", "ReplaceSingleLineLet",
+        "ReplaceJavaStaticMethodWithKotlinAnalog",
+        "NestedLambdaShadowedImplicitParameter"
+)
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class BondInfoTest03 {
+
+/*    @org.junit.jupiter.api.BeforeEach
+    fun setUp() {
+        println("Setup")
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        println("Teardown")
+    }*/
+
+    @Test
+    @DisplayName("touch all hash entries")
+    fun testAllHashEntries() {
+        val bondLookup = BondInfo()
+
+        for (item in bondLookup.kotmolBondLookup) {
+            //println("number of entries in item: ${item.value}")
+
+            val foo = item.value
+            assertNotEquals(0, foo)
+        }
+
+
+    }
+
+    @Test
+    @DisplayName("check badList for orphaned pair")
+    fun testBadList() {
+        val foundMatch = BooleanArray(badList.size)
+        val allTrue = BooleanArray(badList.size) { true }
+        //for (item in badList) {
+        for (i in (badList.indices)) {
+
+            val a1 = badList[i].atom_1
+            val a2 = badList[i].atom_2
+            for (j in (badList.indices)) {
+                if (j == i)
+                    continue
+                val b1 = badList[j].atom_1
+                val b2 = badList[j].atom_2
+                if (a1 == b1
+                        || a1 == b2
+                        || a2 == b1
+                        || a2 == b2) {
+                    foundMatch[i] = true
+                    foundMatch[j] = true
+                    continue // one atom matches at least
+                }
+            }
+        }
+        for (k in (foundMatch.indices)) {
+            if (!foundMatch[k]) {
+                val bad = badList[k]
+                println("Found (expected) orphaned entry: ${badList[k]}")
+            }
+        }
+    }
+
+    /*
+     * a Test List that containes one orphaned pair of bond atoms (NX and NY)
+     */
+    companion object {
+        val badList = listOf(
+                BondInfo.KotmolBondRecord(
+                        aromatic = false,
+                        atom_1 = "C1'",
+                        atom_2 = "H1'",
+                        bond_order = 1f,
+                        bond_type = "sing",
+                        length = 1.095f
+                ),
+                BondInfo.KotmolBondRecord(
+                        aromatic = false,
+                        atom_1 = "NX",
+                        atom_2 = "NY",
+                        bond_order = 1f,
+                        bond_type = "sing",
+                        length = 1.434f
+                ),
+                BondInfo.KotmolBondRecord(
+                        aromatic = false,
+                        atom_1 = "C1'",
+                        atom_2 = "N3",
+                        bond_order = 1f,
+                        bond_type = "sing",
+                        length = 1.402f
+                ))
+    }
+
+//    @Test
+//    @DisplayName( "this should fail")
+//    fun testThisFail() {
+//        assertEquals(1,2 )
+//    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest04.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest04.kt
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+        "unused",
+        "unused_variable",
+        "unused_parameter",
+        "deprecation",
+        "UNUSED_ANONYMOUS_PARAMETER",
+        "UNUSED_EXPRESSION",
+        "MemberVisibilityCanBePrivate",
+        "FunctionWithLambdaExpressionBody",
+        "UnusedMainParameter", "JoinDeclarationAndAssignment",
+        "CanBePrimaryConstructorProperty", "RemoveEmptyClassBody",
+        "ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE", "UNUSED_VALUE",
+        "ConstantConditionIf", "ReplaceSingleLineLet",
+        "ReplaceJavaStaticMethodWithKotlinAnalog",
+        "NestedLambdaShadowedImplicitParameter"
+)
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class BondInfoTest04 {
+    /*
+     * for every bond list, scan the list and verify that all bond pairs have at least one
+     * match of an atom to another atom.   That is to say - in the directed graph
+     * that is described by the bond pairs - there is no orphaned pair orbiting alone.
+     */
+    @Test
+    @DisplayName("check all lists for orphaned bond pairs")
+    fun checkAllListsForOrphanedParis() {
+        val bondLookup = BondInfo()
+
+        for (item in bondLookup.kotmolBondLookup) {
+            scanListForOphanedPairs(item.value, item.key)
+        }
+    }
+
+    /*
+     * the actual scan function - the "foundMatch" boolean array should go completely true
+     * as the connections are tested.
+     */
+    fun scanListForOphanedPairs(testList: List<BondInfo.KotmolBondRecord>, residueName: String) {
+        val foundMatch = BooleanArray(testList.size)
+        val allTrue = BooleanArray(testList.size) { true }
+        //for (item in badList) {
+        for (i in (testList.indices)) {
+
+            val a1 = testList[i].atom_1
+            val a2 = testList[i].atom_2
+            for (j in (testList.indices)) {
+                if (j == i)
+                    continue
+                val b1 = testList[j].atom_1
+                val b2 = testList[j].atom_2
+                if (a1 == b1
+                        || a1 == b2
+                        || a2 == b1
+                        || a2 == b2) {
+                    // minimally one atom matches between the two pairs
+                    foundMatch[i] = true
+                    foundMatch[j] = true
+                    continue
+                }
+            }
+        }
+        for (k in (foundMatch.indices)) {
+            if (!foundMatch[k]) {
+                val bad = testList[k]
+                println("$residueName: Found orphaned entry: ${testList[k]}")
+            }
+        }
+        assertArrayEquals(allTrue, foundMatch)
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest05.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest05.kt
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+@file:Suppress(
+        "unused",
+        "unused_variable",
+        "unused_parameter",
+        "deprecation",
+        "UNUSED_ANONYMOUS_PARAMETER",
+        "UNUSED_EXPRESSION",
+        "MemberVisibilityCanBePrivate",
+        "FunctionWithLambdaExpressionBody",
+        "UnusedMainParameter", "JoinDeclarationAndAssignment",
+        "CanBePrimaryConstructorProperty", "RemoveEmptyClassBody",
+        "ASSIGNED_BUT_NEVER_ACCESSED_VARIABLE", "UNUSED_VALUE",
+        "ConstantConditionIf", "ReplaceSingleLineLet",
+        "ReplaceJavaStaticMethodWithKotlinAnalog",
+        "NestedLambdaShadowedImplicitParameter"
+)
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+// https://stackoverflow.com/a/54938582 - on copying a data class array
+
+internal class BondInfoTest05 {
+    /*
+     *  verify that that map/copy operation creates a clone of a list/data class
+     *    and that there is no reuse of the objects, i.e. pollution of the original
+     *    data class array.
+     */
+    @Test
+    @DisplayName("check that original record that was copied has bondRecordCreated still false")
+    fun checkForCleanCopyOfBondList() {
+        val exampleBondList = BondInfo().ala
+
+        val theCopy = ArrayList(exampleBondList.map { it.copy() })
+
+        exampleBondList[0].bondRecordCreated = true
+
+        val isFlagFalse = theCopy[0].bondRecordCreated
+
+        assertFalse(isFlagFalse)
+        assertTrue(exampleBondList[0].bondRecordCreated)
+        assertFalse(exampleBondList[0] === theCopy[0])
+        assertFalse(exampleBondList[0] == theCopy[0])
+        assertTrue(exampleBondList[1] == theCopy[1])
+    }
+
+
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest06.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/BondInfoTest06.kt
@@ -1,0 +1,144 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class BondInfoTest06 {
+
+    /**
+     * 4AJX - contains H1/H2/H3 atoms bonded to the N atom
+     *    The H1 / H3 atoms were missing from the Bond database.
+     *    Use these examples to add H1 / H3 to the bond info
+     *    and test that they are bonded.
+     */
+    lateinit var str : ByteArrayInputStream
+    lateinit var aModelTest : String
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() {
+        val theModelString = """
+         1         2         3         4         5         6         7
+12345678901234567890123456789012345678901234567890123456789012345678901234567890"""
+        aModelTest = """
+ATOM      1  N   GLY A   1      53.224  -6.918  16.646  1.00 11.20           N
+ATOM      2  CA  GLY A   1      52.194  -6.272  15.815  1.00  9.87           C
+ATOM      3  C   GLY A   1      50.937  -6.027  16.630  1.00  9.81           C
+ATOM      4  O   GLY A   1      50.794  -6.512  17.771  1.00  9.85           O
+ATOM      5  HA2 GLY A   1      52.524  -5.423  15.481  1.00 11.85           H  
+ATOM      6  HA3 GLY A   1      51.974  -6.842  15.061  1.00 11.85           H  
+ATOM      7  H1  GLY A   1      52.824  -7.242  17.457  1.00 13.44           H  
+ATOM      8  H2  GLY A   1      53.610  -7.653  16.164  1.00 13.44           H  
+ATOM      9  H3  GLY A   1      53.909  -6.281  16.860  1.00 13.44           H  
+TER      10                                                                       
+ATOM    362  N   PHE B   1      42.139 -16.805  13.560  1.00 21.72           N
+ATOM    363  CA  PHE B   1      40.918 -17.256  14.255  1.00 19.54           C
+ATOM    364  C   PHE B   1      39.851 -16.185  14.096  1.00 16.61           C
+ATOM    365  O   PHE B   1      40.149 -14.987  13.946  1.00 16.04           O
+ATOM    366  CB  PHE B   1      41.206 -17.513  15.745  1.00 21.28           C
+ATOM    367  CG  PHE B   1      42.194 -18.626  15.997  1.00 24.24           C
+ATOM    368  CD1 PHE B   1      41.841 -19.948  15.781  1.00 23.78           C
+ATOM    369  CD2 PHE B   1      43.468 -18.352  16.479  1.00 26.04           C
+ATOM    370  CE1 PHE B   1      42.738 -20.971  16.015  1.00 26.54           C
+ATOM    371  CE2 PHE B   1      44.370 -19.370  16.734  1.00 25.59           C
+ATOM    372  CZ  PHE B   1      44.008 -20.677  16.503  1.00 26.98           C
+ATOM    373  HA  PHE B   1      40.594 -18.087  13.850  1.00 23.45           H  
+ATOM    374  HB2 PHE B   1      41.567 -16.703  16.138  1.00 25.53           H  
+ATOM    375  HB3 PHE B   1      40.376 -17.750  16.187  1.00 25.53           H  
+ATOM    376  HD1 PHE B   1      40.992 -20.148  15.458  1.00 28.54           H  
+ATOM    377  HD2 PHE B   1      43.716 -17.470  16.640  1.00 31.25           H  
+ATOM    378  HE1 PHE B   1      42.489 -21.854  15.863  1.00 31.85           H  
+ATOM    379  HE2 PHE B   1      45.221 -19.170  17.050  1.00 30.71           H  
+ATOM    380  HZ  PHE B   1      44.615 -21.363  16.663  1.00 32.38           H  
+ATOM    381  H1  PHE B   1      41.924 -16.075  12.976  1.00 26.07           H  
+ATOM    382  H2  PHE B   1      42.788 -16.517  14.207  1.00 26.07           H  
+ATOM    383  H3  PHE B   1      42.501 -17.531  13.046  1.00 26.07           H  
+TER     384                                                                            
+END   
+        """.trimIndent()
+
+        str = aModelTest.byteInputStream()
+
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    /**
+     * make sure there are no bonds between the two residue - i.e. the TER record
+     * stops the bond processing even though the residue numbers are the same
+     */
+    @Test
+    @DisplayName( "test processing of a TER record")
+    fun testTERrecordProcessing() {
+
+        val mol = Molecule()
+        val messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .setMoleculeName("4AJX")
+                .setMessageStrings(messages)
+                .loadPdbFromStream(str)
+                .parse()
+
+        //
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(33, atoms.size)
+
+        // bonds from the two records don't overlap
+        assertEquals(30, mol.bondList.size)
+
+        // check that the TER record is entered into the
+        // atom list as a TER_RECORD type.
+        val shouldBeTER = mol.atomNumberToAtomInfoHash[10]
+        assertNotNull(shouldBeTER)
+        assertEquals(PdbAtom.AtomType.IS_TER_RECORD, shouldBeTER!!.atomType)
+
+    }
+
+
+    /**
+     * make sure there are no bonds between the two residue - i.e. the TER record
+     * stops the bond processing even though the residue numbers are the same
+     */
+    @Test
+    @DisplayName( "test that bond processing is suppressed")
+    fun testDoBondProcessingFlag() {
+
+        val mol = Molecule()
+        val messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .setMoleculeName("4AJX")
+                .setMessageStrings(messages)
+                .loadPdbFromStream(str)
+                .doBondProcessing(false)  // skip over bond processing
+                .parse()
+
+        //
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(33, atoms.size)
+
+        // should have no bonds in bond list
+        assertEquals(0, mol.bondList.size)
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/CONECTtest01.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/CONECTtest01.kt
@@ -1,0 +1,84 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class CONECTtest01 {
+
+    /**
+     * 5W1O -
+     *    has CONECT records with no spaces.   Check that the HETATMs are
+     *    properly CONECT'ed
+     */
+    lateinit var str : ByteArrayInputStream
+    lateinit var aModelTest : String
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() {
+        val theModelString = """
+         1         2         3         4         5         6         7
+12345678901234567890123456789012345678901234567890123456789012345678901234567890"""
+        aModelTest = """
+HETATM17079  S   IDS E 512       8.437   1.398  80.249  1.00 31.19           S  
+HETATM17080  O1S IDS E 512       9.147   0.259  79.768  1.00 31.82           O  
+HETATM17081  O2S IDS E 512       7.206   1.638  79.577  1.00 33.46           O  
+HETATM17082  O3S IDS E 512       9.251   2.557  80.323  1.00 30.40           O  
+CONECT1708017079                                                                
+CONECT1708117079                                                                
+CONECT1708217079                                                                                  
+END    
+        """.trimIndent()
+
+        str = aModelTest.byteInputStream()
+
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    /**
+     *
+     */
+    @Test
+    @DisplayName( "test processing of a TER record")
+    fun testModelSkipping() {
+
+        val mol = Molecule()
+        val messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .setMoleculeName("5W1O")
+                .setMessageStrings(messages)
+                .loadPdbFromStream(str)
+                .parse()
+
+        // four atoms with three CONECT records
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(4, atoms.size)
+
+        // bonds from the two records don't overlap
+        assertEquals(3, mol.bondList.size)
+
+        // TODO: check the Bond list
+
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/ModelTest01.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/ModelTest01.kt
@@ -1,0 +1,89 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class ModelTest01 {
+
+    /**
+     * 1ZNF - a Zinc Finger PDB with 37 models (edited)
+     */
+    lateinit var str : ByteArrayInputStream
+    lateinit var aModelTest : String
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 2r6p
+        val theModelString = """
+         1         2         3         4         5         6         7
+12345678901234567890123456789012345678901234567890123456789012345678901234567890"""
+        aModelTest = """
+MODEL        1                                                                  
+ATOM     55  SG  CYS A   3      -2.153  -3.317   0.825  1.00  0.00           S  
+ATOM     91  SG  CYS A   6      -2.183  -5.291  -2.481  1.00  0.00           S  
+ATOM    303  NE2 HIS A  19      -2.090  -1.975  -2.405  1.00  0.00           N  
+ATOM    377  NE2 HIS A  23      -4.818  -2.975  -1.254  1.00  0.00           N  
+TER     424      NH2 A  26                                                      
+HETATM  425 ZN    ZN A  27      -2.880  -3.408  -1.345  1.00  0.00          ZN  
+ENDMDL                                                                          
+MODEL        2                                                                  
+ATOM      7  N   TYR A   1       7.910  -2.401   1.328  1.00  0.00           N  
+ENDMDL                                                                          
+MODEL        3                                                                  
+ATOM      8  CA  TYR A   1       6.945  -2.325   2.443  1.00  0.00           C  
+ENDMDL                                                                          
+CONECT  425   55   91  303  377                                                 
+MASTER      251    0    3    1    2    1    1    615688   37   16    3          
+END 
+        """.trimIndent()
+
+        str = aModelTest.byteInputStream()
+
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    /**
+     *
+     */
+    @Test
+    @DisplayName( "test that mol has only five atoms, does not include other models, has bonds to Zinc HETATM")
+    fun testModelSkipping() {
+
+        val mol = Molecule()
+        val messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .setMoleculeName("1ZNF")
+                .setMessageStrings(messages)
+                .loadPdbFromStream(str)
+                .parse()
+
+        // only 5 + 1TER atoms, does not include later models
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(5+1, atoms.size)
+
+        // has the 4 bonds from the zinc atom to the previous 4 atoms
+        assertEquals(4, mol.bondList.size)
+
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/ParseTestAtom01.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/ParseTestAtom01.kt
@@ -1,0 +1,51 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class ParseTestAtom01 {
+
+    lateinit var str : ByteArrayInputStream
+    lateinit var anAtom : String
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        anAtom = """
+            ATOM      1  O5'  DC A   1      18.935  34.195  25.617  1.00 64.35           O 
+        """.trimIndent()
+
+        str = anAtom.byteInputStream()
+
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    @Test
+    @DisplayName( "test an ATOM line")
+    fun testThis() {
+        val line = str.readBytes()
+        val str = String(line)
+
+        // println(str)
+        assertEquals(anAtom, str)
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/ParseTestAtom02.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/ParseTestAtom02.kt
@@ -1,0 +1,63 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class ParseTestAtom02 {
+
+    lateinit var stream : ByteArrayInputStream
+    val mol = Molecule()
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        val anAtom = """
+            ATOM      1  O5'  DC A   1      18.935  34.195  25.617  1.00 64.35           O 
+        """.trimIndent()
+
+        stream = anAtom.byteInputStream()
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        stream.close()
+    }
+
+    @Test
+    @DisplayName( "test an ATOM line")
+    fun testThis() {
+
+        var messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .loadPdbFromStream(stream)
+                .parse()
+
+        assertEquals(1, mol.maxAtomNumber)
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(1, atoms.size)
+
+        val firstAtom = atoms[1]
+        assertEquals("O5'", firstAtom?.atomName)
+
+        assertEquals(1,1 )
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/ParseTestAtom03.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/ParseTestAtom03.kt
@@ -1,0 +1,66 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class ParseTestAtom03 {
+
+    lateinit var str : ByteArrayInputStream
+    val mol = Molecule()
+    val parse = ParserPdbFile(mol)
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        val anAtom = """
+ATOM      1  O5'  DC A   1      18.935  34.195  25.617  1.00 64.35           O  
+ATOM      2  C5'  DC A   1      19.130  33.921  24.219  1.00 44.69           C  
+ATOM      3  C4'  DC A   1      19.961  32.668  24.100  1.00 31.28           C 
+        """.trimIndent()
+
+        str = anAtom.byteInputStream()
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    @Test
+    @DisplayName( "test with 3 atoms - should have a bond list of size 2 as a result")
+    fun testWithThreeAtoms() {
+
+        var messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .loadPdbFromStream(str)
+                .parse()
+
+        assertEquals(3, mol.maxAtomNumber)
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(3, atoms.size)
+
+        val firstAtom = atoms[1]
+        assertEquals("O5'", firstAtom?.atomName)
+
+        assertEquals(2, mol.bondList.size)
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/PdbParserTest.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/PdbParserTest.kt
@@ -1,0 +1,73 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class PdbParserTest {
+
+    private lateinit var stream : ByteArrayInputStream
+
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        val anAtom = """
+            ATOM      1  O5'  DC A   1      18.935  34.195  25.617  1.00 64.35           O 
+        """.trimIndent()
+
+        stream = anAtom.byteInputStream()
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        stream.close()
+    }
+
+    @Test
+    @DisplayName( "parser test")
+    fun parserTest01() {
+        val molecule: Molecule = Molecule()
+        val builder = ParserPdbFile.Builder(molecule)
+        assertNotNull(builder)
+    }
+
+    @Test
+    @DisplayName( "parser test with parameters")
+    fun parserTest02() {
+        val molecule: Molecule = Molecule()
+        ParserPdbFile
+                .Builder(molecule)
+                .loadPdbFromStream(stream)
+                .parse()
+        assertEquals(1, molecule.atomNumberToAtomInfoHash.size)
+    }
+
+    @Test
+    @DisplayName( "parser test with parameters and retained messages")
+    fun parserTest03() {
+        val molecule: Molecule = Molecule()
+        val retainedMessages = mutableListOf<String>()
+        assertEquals(0, retainedMessages.size)
+        ParserPdbFile
+                .Builder(molecule)
+                .setMessageStrings(retainedMessages)
+                .loadPdbFromStream(stream)
+                .parse()
+        assertEquals(1, molecule.atomNumberToAtomInfoHash.size)
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/ResidueInsertionCodeTest01.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/ResidueInsertionCodeTest01.kt
@@ -1,0 +1,109 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class ResidueInsertionCodeTest01 {
+
+    /**
+     * @link https://proteopedia.org/wiki/index.php/Unusual_sequence_numbering
+     * 1IGY - residue 82 is distingushed by the insertion codes
+     */
+    lateinit var str : ByteArrayInputStream
+    lateinit var anAtom : String
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 1bna.pdb
+        val numbering = """
+         1         2         3         4         5         6         7
+12345678901234567890123456789012345678901234567890123456789012345678901234567890"""
+        anAtom = """
+ATOM   2856  HE2 HIS B  81      -5.928 -18.845 -19.529  1.00 15.00           H  
+ATOM   2857  N   LEU B  82      -8.102 -23.106 -16.211  1.00 54.46           N  
+ATOM   2858  CA  LEU B  82      -9.303 -22.824 -15.441  1.00 54.46           C  
+ATOM   2859  C   LEU B  82      -9.912 -21.576 -16.058  1.00 54.46           C  
+ATOM   2860  O   LEU B  82      -9.269 -20.528 -16.091  1.00 20.39           O  
+ATOM   2861  CB  LEU B  82      -8.941 -22.562 -13.968  1.00 20.39           C  
+ATOM   2862  CG  LEU B  82      -8.054 -23.612 -13.283  1.00 20.39           C  
+ATOM   2863  CD1 LEU B  82      -6.847 -22.911 -12.724  1.00 20.39           C  
+ATOM   2864  CD2 LEU B  82      -8.799 -24.398 -12.197  1.00 20.39           C  
+ATOM   2865  H   LEU B  82      -7.232 -23.058 -15.763  1.00 15.00           H  
+ATOM   2866  N   SER B  82A    -11.132 -21.699 -16.574  1.00 62.30           N  
+ATOM   2867  CA  SER B  82A    -11.791 -20.565 -17.197  1.00 62.30           C  
+ATOM   2868  C   SER B  82A    -12.893 -19.950 -16.337  1.00 62.30           C  
+ATOM   2869  O   SER B  82A    -12.630 -19.034 -15.567  1.00 94.33           O  
+ATOM   2870  CB  SER B  82A    -12.312 -20.938 -18.582  1.00 94.33           C  
+ATOM   2871  OG  SER B  82A    -12.673 -19.777 -19.303  1.00 94.33           O  
+ATOM   2872  H   SER B  82A    -11.591 -22.564 -16.533  1.00 15.00           H  
+ATOM   2873  HG  SER B  82A    -13.361 -19.305 -18.827  1.00 15.00           H  
+ATOM   2874  N   SER B  82B    -14.121 -20.438 -16.464  1.00 34.63           N  
+ATOM   2875  CA  SER B  82B    -15.223 -19.894 -15.676  1.00 34.63           C  
+ATOM   2876  C   SER B  82B    -15.034 -20.433 -14.273  1.00 34.63           C  
+ATOM   2877  O   SER B  82B    -15.427 -21.559 -13.972  1.00 40.86           O  
+ATOM   2878  CB  SER B  82B    -16.555 -20.371 -16.231  1.00 40.86           C  
+ATOM   2879  OG  SER B  82B    -16.620 -21.784 -16.157  1.00 40.86           O  
+ATOM   2880  H   SER B  82B    -14.289 -21.171 -17.093  1.00 15.00           H  
+ATOM   2881  HG  SER B  82B    -15.905 -22.165 -16.672  1.00 15.00           H  
+ATOM   2882  N   LEU B  82C    -14.401 -19.641 -13.419  1.00 42.01           N  
+ATOM   2883  CA  LEU B  82C    -14.141 -20.088 -12.059  1.00 42.01           C  
+ATOM   2884  C   LEU B  82C    -15.240 -19.853 -11.036  1.00 42.01           C  
+ATOM   2885  O   LEU B  82C    -15.495 -18.731 -10.594  1.00 23.41           O  
+ATOM   2886  CB  LEU B  82C    -12.783 -19.564 -11.585  1.00 23.41           C  
+ATOM   2887  CG  LEU B  82C    -11.648 -20.325 -12.293  1.00 23.41           C  
+ATOM   2888  CD1 LEU B  82C    -10.291 -19.676 -12.115  1.00 23.41           C  
+ATOM   2889  CD2 LEU B  82C    -11.628 -21.757 -11.785  1.00 23.41           C  
+ATOM   2890  H   LEU B  82C    -14.107 -18.751 -13.705  1.00 15.00           H  
+ATOM   2891  N   THR B  83     -15.949 -20.929 -10.732  1.00 24.92           N
+        """.trimIndent()
+
+        str = anAtom.byteInputStream()
+
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    @Test
+    @DisplayName( "test the handling of Residue Insertion Codes")
+    fun testResidueInsertionCodeHandling() {
+
+        val mol = Molecule()
+        var messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .setMessageStrings(messages)
+                .loadPdbFromStream(str)
+                .parse()
+
+        assertEquals(2891, mol.maxAtomNumber)
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(36, atoms.size)
+
+        val firstAtomNumber = mol.atomNumberList[0]
+        val firstAtom = mol.atomNumberToAtomInfoHash[firstAtomNumber]
+        assertNotNull(firstAtom)
+        assertEquals("HE2", firstAtom!!.atomName)
+
+
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/ResidueInsertionCodeTest02.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/ResidueInsertionCodeTest02.kt
@@ -1,0 +1,82 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class ResidueInsertionCodeTest02 {
+
+    /**
+     * 2R6P - a CA only PDB model
+     */
+    lateinit var str : ByteArrayInputStream
+    lateinit var anAtom : String
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 2r6p
+        val numbering = """
+         1         2         3         4         5         6         7
+12345678901234567890123456789012345678901234567890123456789012345678901234567890"""
+        anAtom = """
+ATOM      1  CA  MET A   1      93.887  11.659 215.822  1.00 70.94           C  
+ATOM      2  CA  ARG A   2      90.531  10.195 214.833  1.00 72.65           C  
+ATOM      3  CA  CYS A   3      91.669   6.554 215.139  1.00 63.88           C  
+ATOM      4  CA  ILE A   4      92.293   6.900 218.830  1.00 73.59           C  
+ATOM      5  CA  GLY A   5      89.515   5.137 220.704  1.00 75.00           C  
+ATOM      6  CA  ILE A   6      88.514   2.427 217.829  1.00 75.00           C  
+ATOM      7  CA  SER A   7      89.320  -0.852 218.358  1.00 75.00           C  
+ATOM      8  CA  ASN A   8      89.792  -2.127 214.851  1.00 75.00           C  
+ATOM      9  CA  ARG A   9      92.907   0.305 214.038  1.00 73.62           C  
+        """.trimIndent()
+
+        str = anAtom.byteInputStream()
+
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    @Test
+    @DisplayName( "test only CA atoms in PDB")
+    fun testOnlyCAatomsInPDB() {
+
+        val mol = Molecule()
+        val messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .setMoleculeName("2R6P")
+                .setMessageStrings(messages)
+                .loadPdbFromStream(str)
+                .parse()
+
+        assertEquals(9, mol.maxAtomNumber)
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(9, atoms.size)
+
+//        val firstAtomNumber = mol.numList[0]
+//        val firstAtom = mol.atoms[firstAtomNumber]
+//        assertNotNull(firstAtom)
+//        assertEquals("HE2", firstAtom!!.atomName)
+
+
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/RibbonCAonlyTest.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/RibbonCAonlyTest.kt
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import com.kotmol.pdbParser.ChainRenderingDescriptor.NucleicType.NOT_A_NUCLEIC_TYPE
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class RibbonCAonlyTest {
+
+    /**
+     * @link https://proteopedia.org/wiki/index.php/Unusual_sequence_numbering
+     * 1IGY - residue 82 is distingushed by the insertion codes
+     */
+    lateinit var str : ByteArrayInputStream
+    lateinit var anAtom : String
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() { // from 3ixz CA only
+        val numbering = """
+         1         2         3         4         5         6         7
+12345678901234567890123456789012345678901234567890123456789012345678901234567890"""
+        anAtom = """
+ATOM      1  CA  LYS A  36      38.866  60.745 -26.642  1.00  0.00           C  
+ATOM      2  CA  ARG A  37      40.620  57.631 -25.579  1.00  0.00           C  
+ATOM      3  CA  LYS A  38      38.386  54.647 -26.046  1.00  0.00           C  
+ATOM      4  CA  GLU A  39      40.092  53.260 -23.023  1.00  0.00           C  
+ATOM      5  CA  LYS A  40      38.483  55.954 -20.912  1.00  0.00           C  
+ATOM      6  CA  LEU A  41      35.218  56.618 -22.675  1.00  0.00           C  
+ATOM      7  CA  GLU A  42      34.406  52.949 -23.237  1.00  0.00           C  
+ATOM      8  CA  ASN A  43      36.549  51.336 -20.567  1.00  0.00           C  
+ATOM      9  CA  MET A  44      35.713  53.288 -17.402  1.00  0.00           C  
+        """.trimIndent()
+
+        str = anAtom.byteInputStream()
+
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    @Test
+    @DisplayName( "test a CA only PDB file for only a ribbon")
+    fun testCAonlyPDBfile() {
+
+        val mol = Molecule()
+        var messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .setMessageStrings(messages)
+                .loadPdbFromStream(str)
+                .parse()
+
+        assertEquals(9, mol.maxAtomNumber)
+
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(9, atoms.size)
+
+        // chain list is also 1 long - has one chain with 9 atoms in the chain
+        val chainDescList = mol.listofChainDescriptorLists
+        assertEquals(1, chainDescList.size)
+
+        /*
+         * there is only one chain in this short PDB
+         *    Walk this chain and verify that the guide atom (CA only)
+         * is equivalent to the atom number.
+         */
+        val chain = chainDescList[0]
+        for (item in chain.withIndex()) {
+            assertEquals(NOT_A_NUCLEIC_TYPE, item.value.nucleicType)
+            assertNull(item.value.startAtom)
+            assertNull(item.value.endAtom)
+            val backbone = item.value.backboneAtom
+            val guide = item.value.guideAtom
+            assertNotNull(backbone)
+            //assertNotNull(guide)
+            assertEquals(item.index+1, backbone!!.atomNumber)
+            //assertEquals(item.index+1, guide!!.atomNumber)
+
+        }
+
+
+    }
+}

--- a/pdbparser/src/test/java/com/kotmol/pdbParser/TERtest01.kt
+++ b/pdbparser/src/test/java/com/kotmol/pdbParser/TERtest01.kt
@@ -1,0 +1,121 @@
+/*
+ *  Copyright 2020 James Andreas
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package com.kotmol.pdbParser
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import com.kotmol.pdbParser.PdbAtom.AtomType.IS_TER_RECORD
+
+// https://blog.jetbrains.com/idea/2016/08/using-junit-5-in-intellij-idea/
+
+internal class TERtest01 {
+
+    /**
+     * 1ZNF - a Zinc Finger PDB with 37 models (edited)
+     *    What is unique about this test case is that the same
+     *    residue number is used across a TER record.  The residue names
+     *    change.   The TER record asserts that the chain ends there.
+     */
+    lateinit var str : ByteArrayInputStream
+    lateinit var aModelTest : String
+    @org.junit.jupiter.api.BeforeEach
+    fun setUp() {
+        val theModelString = """
+         1         2         3         4         5         6         7
+12345678901234567890123456789012345678901234567890123456789012345678901234567890"""
+        aModelTest = """
+ATOM    204  P    DT E  12      41.677 -64.307   5.732  1.00122.09           P  
+ATOM    205  OP1  DT E  12      41.863 -63.536   6.997  1.00122.09           O  
+ATOM    206  OP2  DT E  12      40.540 -65.263   5.602  1.00122.09           O  
+ATOM    207  O5'  DT E  12      41.490 -63.265   4.544  1.00122.09           O  
+ATOM    208  C5'  DT E  12      41.284 -63.725   3.216  1.00122.09           C  
+ATOM    209  C4'  DT E  12      41.127 -62.551   2.284  1.00122.09           C  
+ATOM    210  O4'  DT E  12      42.352 -61.765   2.361  1.00122.09           O  
+ATOM    211  C3'  DT E  12      41.055 -63.092   0.847  1.00122.09           C  
+ATOM    212  O3'  DT E  12      40.589 -62.225  -0.194  1.00122.09           O  
+ATOM    213  C2'  DT E  12      42.507 -63.144   0.452  1.00122.09           C  
+ATOM    214  C1'  DT E  12      42.986 -61.878   1.111  1.00122.09           C  
+ATOM    215  N1   DT E  12      44.435 -61.796   1.185  1.00122.09           N  
+ATOM    216  C2   DT E  12      45.194 -62.908   1.513  1.00122.09           C  
+ATOM    217  O2   DT E  12      44.746 -63.884   2.121  1.00121.05           O  
+ATOM    218  N3   DT E  12      46.495 -62.834   1.058  1.00122.05           N  
+ATOM    219  C4   DT E  12      47.050 -61.795   0.349  1.00122.09           C  
+ATOM    220  O4   DT E  12      48.112 -61.938  -0.174  1.00122.09           O  
+ATOM    221  C5   DT E  12      46.248 -60.610   0.228  1.00122.09           C  
+ATOM    222  C7   DT E  12      46.823 -59.410  -0.452  1.00122.09           C  
+ATOM    223  C6   DT E  12      45.009 -60.650   0.696  1.00122.09           C  
+TER     224       DT E  12                                                      
+ATOM    225  O5'  DA D  12      57.253 -61.992  -0.544  1.00117.97           O  
+ATOM    226  C5'  DA D  12      57.447 -61.049  -1.619  1.00120.06           C  
+ATOM    227  C4'  DA D  12      56.212 -60.189  -1.578  1.00122.09           C  
+ATOM    228  O4'  DA D  12      55.088 -61.095  -1.431  1.00122.09           O  
+ATOM    229  C3'  DA D  12      56.193 -59.244  -0.360  1.00122.09           C  
+ATOM    230  O3'  DA D  12      55.679 -57.956  -0.705  1.00122.09           O  
+ATOM    231  C2'  DA D  12      55.383 -59.973   0.710  1.00122.09           C  
+ATOM    232  C1'  DA D  12      54.568 -60.901  -0.144  1.00122.09           C  
+ATOM    233  N9   DA D  12      53.641 -61.943   0.293  1.00122.09           N  
+ATOM    234  C8   DA D  12      53.592 -63.296   0.675  1.00122.09           C  
+ATOM    235  N7   DA D  12      52.407 -63.697   1.027  1.00122.09           N  
+ATOM    236  C5   DA D  12      51.648 -62.522   0.878  1.00122.09           C  
+ATOM    237  C6   DA D  12      50.290 -62.250   1.103  1.00122.09           C  
+ATOM    238  N6   DA D  12      49.433 -63.180   1.501  1.00122.09           N  
+ATOM    239  N1   DA D  12      49.855 -60.973   0.861  1.00122.09           N  
+ATOM    240  C2   DA D  12      50.735 -60.076   0.425  1.00122.09           C  
+ATOM    241  N3   DA D  12      52.029 -60.220   0.194  1.00122.09           N  
+ATOM    242  C4   DA D  12      52.392 -61.477   0.435  1.00122.09           C  
+        """.trimIndent()
+
+        str = aModelTest.byteInputStream()
+
+    }
+
+    @org.junit.jupiter.api.AfterEach
+    fun tearDown() {
+        str.close()
+    }
+
+    /**
+     *
+     */
+    @Test
+    @DisplayName( "test processing of a TER record")
+    fun testModelSkipping() {
+
+        val mol = Molecule()
+        val messages : MutableList<String> = mutableListOf()
+
+        ParserPdbFile
+                .Builder(mol)
+                .setMoleculeName("1ZNF")
+                .setMessageStrings(messages)
+                .loadPdbFromStream(str)
+                .parse()
+
+        // two residues separated by a TER record (see above)
+        val atoms = mol.atomNumberToAtomInfoHash
+        assertEquals(39, atoms.size)
+
+        // bonds from the two records don't overlap
+        assertEquals(41, mol.bondList.size)
+
+        // check that the TER record is entered into the
+        // atom list as a TER_RECORD type.
+        val shouldBeTER = mol.atomNumberToAtomInfoHash[224]
+        assertNotNull(shouldBeTER)
+        assertEquals(IS_TER_RECORD, shouldBeTER!!.atomType)
+
+    }
+}

--- a/standalone/build.gradle.kts
+++ b/standalone/build.gradle.kts
@@ -111,7 +111,7 @@ dependencies {
     implementation(libs.androidx.preference.ktx)
 
     implementation(libs.okhttp)
-    implementation(libs.pdbparser)
+    implementation(project(":pdbparser"))
     implementation(libs.timber)
     implementation(libs.picasso)
 }


### PR DESCRIPTION
## Summary

- Replaces the external Maven dependency `com.kotmol.kotmolpdbparser:kotmolpdbparser:1.0.5` with a local Gradle module at `pdbparser/`
- Copies 8 core source files + 23 unit tests from `KotmolPdbParser`; package name `com.kotmol.pdbParser` is unchanged so no import edits were needed in `mollib/`
- Updates 4 consuming modules (mollib, motmbrowser, standalone, captureimages) to use `project(":pdbparser")` instead of `libs.pdbparser`
- Fixes 6 deprecated `toLowerCase()` → `lowercase()` / `lowercaseChar()` calls in `ParserPdbFile.kt` for Kotlin 2.3 compatibility
- Adds `CLAUDE-integrate-pdbparser.md` documenting the integration, module layout, and how to sync future upstream changes

## Test plan

- [x] `./gradlew.bat :pdbparser:test` — all 27 pdbparser tests pass (1 skipped by design)
- [x] `./gradlew.bat build` — full build of all modules succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)